### PR TITLE
Add advanced Bluetooth codec support (LDAC, aptX, AAC) via pulseaudio-modules-bt

### DIFF
--- a/packages/audio/pulseaudio-modules-bt/package.mk
+++ b/packages/audio/pulseaudio-modules-bt/package.mk
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present CoreELEC (https://coreelec.org)
+
+PKG_NAME="pulseaudio-modules-bt"
+PKG_VERSION="1.4"
+PKG_SHA256="72f8ffa46f842c2637b4d51d6db88a013002737acd36abb5f44ad049e8ccdf13"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/EHfive/pulseaudio-modules-bt"
+PKG_URL="https://github.com/EHfive/pulseaudio-modules-bt/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain pulseaudio ldacBT libfreeaptx fdk-aac ffmpeg"
+PKG_LONGDESC="Adds Sony LDAC, aptX, aptX HD, AAC codecs (A2DP Audio) support to PulseAudio"
+PKG_TOOLCHAIN="cmake"
+
+PKG_CMAKE_OPTS_TARGET="-DCODEC_LDAC=ON \
+                       -DCODEC_AAC_FDK=ON \
+                       -DCODEC_APTX_FF=ON \
+                       -DCODEC_APTX_HD_FF=ON \
+                       -DFORCE_LARGEST_PA_VERSION=ON"
+
+pre_configure_target() {
+  # pulseaudio-modules-bt expects PulseAudio source in pa/src directory  # The CMakeLists.txt does: include_directories(pa/src)
+  # And then includes <pulsecore/core.h>, so it needs pa/src/pulsecore/
+  # Link pa/src to PulseAudio build src directory
+  rm -rf ${PKG_BUILD}/pa/src
+  ln -sf ${BUILD}/build/pulseaudio-17.0/src ${PKG_BUILD}/pa/src
+}
+
+post_makeinstall_target() {
+  echo "PulseAudio Bluetooth modules with LDAC/aptX/AAC support installed"
+}

--- a/packages/audio/pulseaudio-modules-bt/patches/pulseaudio-modules-bt-01-ffmpeg7-compat.patch
+++ b/packages/audio/pulseaudio-modules-bt/patches/pulseaudio-modules-bt-01-ffmpeg7-compat.patch
@@ -1,0 +1,22 @@
+--- a/src/modules/bluetooth/a2dp/a2dp_aptx.c
++++ b/src/modules/bluetooth/a2dp/a2dp_aptx.c
+@@ -255,7 +255,7 @@ static size_t pa_dual_encode(void *codec_info, uint32_t timestamp, const uint8_
+     av_frame = av_frame_alloc_func();
+     av_frame->nb_samples = aptx_info->nb_samples;
+     av_frame->format = aptx_info->av_codec_ctx->sample_fmt;
+-    av_frame->channel_layout = aptx_info->av_codec_ctx->channel_layout;
++    av_channel_layout_default(&av_frame->ch_layout, 2);
+ 
+     pkt = av_packet_alloc_func();
+ 
+@@ -346,8 +346,8 @@ static void pa_dual_config_transport(pa_a2dp_codec_t *codec) {
+ 
+     switch (config->channel_mode) {
+         case APTX_CHANNEL_MODE_STEREO:
+-            aptx_ctx->channel_layout = AV_CH_LAYOUT_STEREO;
+-            aptx_ctx->channels = 2;
++            av_channel_layout_default(&aptx_ctx->ch_layout, 2);
++            aptx_ctx->ch_layout.nb_channels = 2;
+             sample_spec->channels = 2;
+             break;
+         default:

--- a/packages/audio/pulseaudio-modules-bt/patches/pulseaudio-modules-bt-02-link-ffmpeg-libs.patch
+++ b/packages/audio/pulseaudio-modules-bt/patches/pulseaudio-modules-bt-02-link-ffmpeg-libs.patch
@@ -1,0 +1,9 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -85,6 +85,7 @@ if(${AVCODEC_FOUND} AND ${AVUTIL_FOUND})
+     if ("${PA_A2DP_CODEC_APTX_FF}" OR "${PA_A2DP_CODEC_APTX_HD_FF}")
+         set(bluez5_util_SOURCES ${bluez5_util_SOURCES} ${MOD_BT_DIR}/a2dp/a2dp_aptx.c ${MOD_BT_DIR}/a2dp/ffmpeg_libs.c)
++        set(bluez5_util_LIBS ${bluez5_util_LIBS} ${AVCODEC_LIBRARIES} ${AVUTIL_LIBRARIES})
+         if(NOT "${AVCODEC_LIBRARY_DIRS}" STREQUAL "")
+             set(bluez5_util_RPATH ${bluez5_util_RPATH}:${AVCODEC_LIBRARY_DIRS})
+         endif()

--- a/packages/audio/pulseaudio-modules-bt/patches/pulseaudio-modules-bt-03-ffmpeg8-libversions.patch
+++ b/packages/audio/pulseaudio-modules-bt/patches/pulseaudio-modules-bt-03-ffmpeg8-libversions.patch
@@ -1,0 +1,20 @@
+--- a/src/modules/bluetooth/a2dp/ffmpeg_libs.c
++++ b/src/modules/bluetooth/a2dp/ffmpeg_libs.c
+@@ -35,7 +35,7 @@
+ #include "ffmpeg_libs.h"
+ 
+ static const char *AVCODEC_LIB_NAMES[] = {
+-        "libavcodec.so.58",
++        "libavcodec.so.62",
+         "libavcodec.so"
+ };
+ 
+@@ -66,7 +66,7 @@ avcodec_free_context_func_t avcodec_free_context_func;
+ avcodec_open2_func_t avcodec_open2_func;
+ 
+ static const char *AVUTIL_LIB_NAMES[] = {
+-        "libavutil.so.56",
++        "libavutil.so.60",
+         "libavutil.so"
+ };
+ 

--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -12,10 +12,11 @@ PKG_DEPENDS_TARGET="toolchain alsa-lib dbus glib libcap libsndfile libtool opens
 PKG_LONGDESC="PulseAudio is a sound system for POSIX OSes, meaning that it is a proxy for your sound applications."
 
 if [ "${BLUETOOTH_SUPPORT}" = "yes" ]; then
-  PKG_DEPENDS_TARGET+=" sbc bluez gstreamer gst-plugins-bad"
+  PKG_DEPENDS_TARGET+=" sbc bluez"
   PKG_PULSEAUDIO_BLUETOOTH="-Dbluez5=enabled"
-  PKG_PULSEAUDIO_BT_GSTREAMER="-Dbluez5-gstreamer=enabled"
-  PKG_PULSEAUDIO_GSTREAMER="-Dgstreamer=enabled"
+  # Disable GStreamer support - pulseaudio-modules-bt will provide codecs
+  PKG_PULSEAUDIO_BT_GSTREAMER="-Dbluez5-gstreamer=disabled"
+  PKG_PULSEAUDIO_GSTREAMER="-Dgstreamer=disabled"
 else
   PKG_PULSEAUDIO_BLUETOOTH="-Dbluez5=disabled"
   PKG_PULSEAUDIO_BT_GSTREAMER="-Dbluez5-gstreamer=disabled"

--- a/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -10,22 +10,7 @@ PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-bad/${PKG_NAME}-${PKG
 PKG_DEPENDS_TARGET="toolchain gst-plugins-base"
 PKG_LONGDESC="GStreamer Bad Plug-ins is a set of plug-ins that aren't up to par compared to the rest."
 
-if [ "${BLUETOOTH_SUPPORT}" = "yes" ]; then
-  PKG_DEPENDS_TARGET+=" fdk-aac sbc ldacBT libfreeaptx"
-fi
-
 pre_configure_target() {
-  if [ "${BLUETOOTH_SUPPORT}" = "yes" ]; then
-    PKG_GST_BT_FDKAAC="-Dfdkaac=enabled"
-    PKG_GST_BT_SBC="-Dsbc=enabled"
-    PKG_GST_BT_EXTRA="-Dldac=enabled \
-                       -Dopenaptx=enabled"
-  else
-    PKG_GST_BT_FDKAAC="-Dfdkaac=disabled"
-    PKG_GST_BT_SBC="-Dsbc=disabled"
-    PKG_GST_BT_EXTRA=""
-  fi
-
   PKG_MESON_OPTS_TARGET="-Dgst_play_tests=false \
                          -Daccurip=disabled \
                          -Dadpcmdec=disabled \
@@ -120,7 +105,7 @@ pre_configure_target() {
                          -Dfaac=disabled \
                          -Dfaad=disabled \
                          -Dfbdev=disabled \
-                         ${PKG_GST_BT_FDKAAC} \
+                         -Dfdkaac=disabled \
                          -Dflite=disabled \
                          -Dfluidsynth=disabled \
                          -Dgl=disabled \
@@ -152,8 +137,7 @@ pre_configure_target() {
                          -Dresindvd=disabled \
                          -Drsvg=disabled \
                          -Drtmp=disabled \
-                         ${PKG_GST_BT_SBC} \
-                         ${PKG_GST_BT_EXTRA} \
+                         -Dsbc=disabled \
                          -Dsctp=disabled \
                          -Dshm=disabled \
                          -Dsmoothstreaming=disabled \

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -15,7 +15,7 @@ pre_configure_target() {
   PKG_MESON_OPTS_TARGET="-Dgl=disabled \
                          -Dadder=disabled \
                          -Dapp=disabled \
-                         -Daudioconvert=enabled \
+                         -Daudioconvert=disabled \
                          -Daudiomixer=disabled \
                          -Daudiorate=disabled \
                          -Daudioresample=disabled \
@@ -63,16 +63,6 @@ pre_configure_target() {
 }
 
 post_makeinstall_target() {
-  if [ "${BLUETOOTH_SUPPORT}" = "yes" ]; then
-    # Keep shared libraries needed by BT audio codec GStreamer plugins
-    safe_remove ${INSTALL}/usr/include
-    safe_remove ${INSTALL}/usr/lib/pkgconfig
-    # Keep audioconvert plugin for BT codec format negotiation
-    safe_remove ${INSTALL}/usr/lib/gstreamer-1.0/libgstrawparse.so
-    safe_remove ${INSTALL}/usr/lib/gstreamer-1.0/libgstsubparse.so
-    safe_remove ${INSTALL}/usr/share
-  else
-    # clean up
-    safe_remove ${INSTALL}
-  fi
+  # clean up
+  safe_remove ${INSTALL}
 }

--- a/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -13,7 +13,7 @@ PKG_LONGDESC="GStreamer open-source multimedia framework core library"
 pre_configure_target() {
   PKG_MESON_OPTS_TARGET="-Dgst_debug=false \
                          -Dgst_parse=true \
-                         -Dregistry=true \
+                         -Dregistry=false \
                          -Dtracer_hooks=false \
                          -Doption-parsing=true \
                          -Dpoisoning=false \

--- a/projects/Amlogic-ce/devices/Amlogic-ng/options
+++ b/projects/Amlogic-ce/devices/Amlogic-ng/options
@@ -141,7 +141,7 @@
   # additional packages to install:
   # Space separated list is supported,
   # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
-    ADDITIONAL_PACKAGES+=" tmate"
+    ADDITIONAL_PACKAGES+=" tmate pulseaudio-modules-bt"
 
   # add OOTB support for IR remote
   # IR_REMOTE_KEYMAPS+=""
@@ -156,3 +156,5 @@
 
   # TEE supported SoC
     TEE_SOC="S905X4"
+
+    BLUETOOTH_SUPPORT="yes"


### PR DESCRIPTION
## Summary

Replace PulseAudio's GStreamer-based Bluetooth backend with pulseaudio-modules-bt to provide high-quality Bluetooth audio codec support.

## Motivation

PulseAudio 17.0's native GStreamer Bluetooth codec support had limitations:
- Codec-specific profiles not appearing in `pactl`
- GStreamer plugin registry unavailable at PulseAudio startup
- Audio quality and stability issues

This PR replaces the GStreamer approach with [pulseaudio-modules-bt](https://github.com/EHfive/pulseaudio-modules-bt), which provides direct integration with codec libraries.

## Changes

### 1. Revert Previous GStreamer Implementation
- Removes GStreamer codec dependencies
- Reverts PulseAudio GStreamer codec configuration

### 2. Disable GStreamer in PulseAudio
- Set `-Dgstreamer=disabled`
- Set `-Dbluez5-gstreamer=disabled`
- Keep `-Dbluez5=enabled` for base Bluetooth support

### 3. Add pulseaudio-modules-bt Package
- Version 1.4 from https://github.com/EHfive/pulseaudio-modules-bt
- Codecs: LDAC, AAC (fdk-aac), aptX (FFmpeg), aptX HD (FFmpeg)
- Dependencies: pulseaudio, ldacBT, libfreeaptx, fdk-aac, ffmpeg

**Patches for FFmpeg 8.0 Compatibility:**
1. **pulseaudio-modules-bt-01-ffmpeg7-compat.patch**: Updates to FFmpeg 7+/8.x channel layout API
2. **pulseaudio-modules-bt-02-link-ffmpeg-libs.patch**: Fixes missing FFmpeg library linking
3. **pulseaudio-modules-bt-03-ffmpeg8-libversions.patch**: Updates FFmpeg library versions (so.58→so.62, so.56→so.60)

### 4. Enable for Amlogic-ng Devices
- Add `pulseaudio-modules-bt` to `ADDITIONAL_PACKAGES`

## Codec Support

| Codec | Bitrate | Quality | Status |
|-------|---------|---------|--------|
| LDAC | up to 990kbps | Highest | ✅ Encoding only |
| aptX HD | 576kbps | Very High | ✅ Full support |
| aptX | 384kbps | High | ✅ Full support |
| AAC | 256kbps | High | ✅ Full support |
| SBC | 328kbps | Baseline | ✅ Full support |

**Priority Order:** LDAC > aptX HD > aptX > AAC > SBC

The highest quality codec supported by both devices is selected automatically. Users can manually switch:
\`\`\`bash
pactl set-card-profile bluez_card.XX_XX_XX_XX_XX_XX a2dp_sink_ldac
\`\`\`

## Testing

**Hardware:**
- Device: CoreELEC Amlogic-ng (aarch64)
- Headphones: Google Pixel Buds Pro (AAC support)

**Results:**
- ✅ PulseAudio loads without errors
- ✅ All codec modules load successfully
- ✅ Codec-specific profiles appear in \`pactl list cards\`
- ✅ AAC codec auto-selected (highest supported by Pixel Buds Pro)
- ✅ Audio streams successfully
- ✅ Manual codec switching works

**Example Output:**
\`\`\`
Profiles:
  a2dp_sink_sbc: High Fidelity Playback (A2DP Sink: SBC) (available: yes)
  a2dp_sink_aac: High Fidelity Playback (A2DP Sink: AAC) (available: yes)
  a2dp_sink_aptx: High Fidelity Playback (A2DP Sink: aptX) (available: no)
  a2dp_sink_aptx_hd: High Fidelity Playback (A2DP Sink: aptX HD) (available: no)
  a2dp_sink_ldac: High Fidelity Playback (A2DP Sink: LDAC) (available: no)
Active Profile: a2dp_sink_aac
\`\`\`

## Notes

- LDAC encoding only (transmission to headphones). Decoding not available as libldacBT provides encoder only.
- Patches are required for FFmpeg 8.0 compatibility (CoreELEC uses FFmpeg 8.0.1)

🤖 Generated with Claude Code