### PR TITLE
Add dynamic fetch of Don't Panic repository at build time

### DIFF
--- a/projects/Amlogic-ce/packages/mediacenter/kodi/package.mk
+++ b/projects/Amlogic-ce/packages/mediacenter/kodi/package.mk
@@ -420,6 +420,22 @@ post_makeinstall_target() {
     sed -e "s|@ADDON_REPO_NAME@|${ADDON_REPO_NAME}|g" -i ${INSTALL}/usr/share/kodi/addons/${ADDON_REPO_ID}/addon.xml
     sed -e "s|@ADDON_VERSION@|${ADDON_VERSION}|g" -i ${INSTALL}/usr/share/kodi/addons/${ADDON_REPO_ID}/addon.xml
 
+  # Download and install Don't Panic repository from official source
+  # Dynamically fetch the latest version from pm4k.eu
+  DONTPANIC_FILE=$(curl -sL https://pm4k.eu | grep -oP 'repository\.dontpanic[^"]*\.zip' | head -1)
+  if [ -n "${DONTPANIC_FILE}" ]; then
+    DONTPANIC_URL="https://pm4k.eu/${DONTPANIC_FILE}"
+    DONTPANIC_ZIP="${BUILD}/repository.dontpanic.zip"
+    echo "Fetching Don't Panic repository: ${DONTPANIC_FILE}"
+    curl -Lsf -o "${DONTPANIC_ZIP}" "${DONTPANIC_URL}"
+    if [ -f "${DONTPANIC_ZIP}" ]; then
+      unzip -q "${DONTPANIC_ZIP}" -d ${INSTALL}/usr/share/kodi/addons/
+      rm -f "${DONTPANIC_ZIP}"
+    fi
+  else
+    echo "WARNING: Could not fetch Don't Panic repository from pm4k.eu"
+  fi
+
   mkdir -p ${INSTALL}/usr/share/kodi/config
 
   ln -sf /run/libreelec/cacert.pem ${INSTALL}/usr/share/kodi/system/certs/cacert.pem


### PR DESCRIPTION
## Summary
- Dynamically download and install `repository.dontpanic` from the official source (https://pm4k.eu) during the build process
- Parses the latest repository ZIP version from pm4k.eu at build time — no hardcoded version numbers
- Follows the same pattern as the existing `repository.coreelec` installation in `post_makeinstall_target()`

## Benefits
- Always uses the latest version from the official source
- No manual updates needed when new versions are released
- Version-agnostic (works with 0.2.9, 0.3.0, and future versions)

## Test plan
- [ ] Build CoreELEC and verify `repository.dontpanic` is present in `/usr/share/kodi/addons/`
- [ ] Verify the downloaded version matches the latest on pm4k.eu
- [ ] Verify build succeeds even if pm4k.eu is temporarily unreachable (warning is printed, build continues)