### PR TITLE
Fix missing repository.dontpanic during build

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -427,6 +427,9 @@ post_makeinstall_target() {
   if [ -n "${DISTRO_PKG_SETTINGS}" ]; then
     xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "${DISTRO_PKG_SETTINGS_ID}" ${ADDON_MANIFEST}
   fi
+  if [ -d "${INSTALL}/usr/share/kodi/addons/repository.dontpanic" ]; then
+    xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "repository.dontpanic" ${ADDON_MANIFEST}
+  fi
 
   if [ "${DRIVER_ADDONS_SUPPORT}" = "yes" ]; then
     xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "script.program.driverselect" ${ADDON_MANIFEST}


### PR DESCRIPTION
## Problem

  The previous commit (Add dynamic fetch of Don't Panic repository at build time) downloads and installs repository.dontpanic to /usr/share/kodi/addons/ at build time, but never
  registers it in addon-manifest.xml. This was confirmed live on device — the addon was physically present but the database had it as enabled=0, so it was invisible in the addon
  browser after a fresh install or reset.

  Kodi's SyncInstalled() inserts any addon found on disk as enabled=0 unless it appears in the manifest. System repos like repository.coreelec and repository.xbmc.org show up
  correctly because they are in the manifest.

##  Fix

  Add repository.dontpanic to addon-manifest.xml at build time using the same xmlstarlet pattern already used for repository.coreelec and service.coreelec.settings. The check [ -d
  ... ] ensures the entry is only added if the download actually succeeded during the build, avoiding a Kodi fatal error if the fetch from pm4k.eu fails.

  ---