### PR TITLE
Dv hvcc passthrough

### DIFF
--- a/.github/workflows/kodi-dv-build.yml
+++ b/.github/workflows/kodi-dv-build.yml
@@ -47,9 +47,10 @@ jobs:
           ARCH: arm
           CCACHE_DIR: /home/runner/.ccache
         run: |
+          set -o pipefail
           export CCACHE_MAXSIZE=6G
           ccache -M 6G || true
-          ./scripts/build kodi 2>&1 | tail -2000
+          ./scripts/build kodi 2>&1 | tee build-kodi.log | tail -2000
 
       - name: Locate kodi build output
         if: always()

--- a/.github/workflows/kodi-dv-build.yml
+++ b/.github/workflows/kodi-dv-build.yml
@@ -1,0 +1,82 @@
+name: Build patched Kodi for CoreELEC Amlogic-ne
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [dv-hvcc-passthrough]
+
+jobs:
+  build-kodi:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY" /opt/hostedtoolcache /usr/local/lib/android || true
+          sudo apt-get clean || true
+          df -h
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            bash bc bison bsdmainutils build-essential ccache cpio flex gawk \
+            gperf lzop libncurses5-dev rsync texinfo unzip u-boot-tools wget \
+            xfonts-utils xmlstarlet xsltproc zip python3 python3-distutils \
+            git patch perl file xz-utils default-jre-headless \
+            libssl-dev libparse-yapp-perl libjson-perl libxml-parser-perl \
+            diffutils gzip tar sed gcc g++ make patchutils rdfind zstd \
+            ca-certificates curl
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-kodi-v2
+          restore-keys: |
+            ccache-kodi-
+
+      - name: Build kodi (single package)
+        env:
+          PROJECT: Amlogic-ce
+          DEVICE: Amlogic-ne
+          ARCH: arm
+          CCACHE_DIR: /home/runner/.ccache
+        run: |
+          export CCACHE_MAXSIZE=6G
+          ccache -M 6G || true
+          ./scripts/build kodi 2>&1 | tail -2000
+
+      - name: Locate kodi build output
+        if: always()
+        run: |
+          echo "=== build dir contents ==="
+          ls -la build.*/ 2>/dev/null | head -20 || true
+          echo "=== kodi .install_pkg tree ==="
+          find build.* -path '*/kodi-*/.install_pkg/usr/lib/kodi*' -type f 2>/dev/null | head -30 || true
+          echo "=== kodi.bin ==="
+          find build.* -name 'kodi.bin' -type f 2>/dev/null || true
+
+      - name: Upload kodi install tree
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kodi-install-arm
+          path: |
+            build.*/kodi-*/.install_pkg/usr/lib/kodi/**
+            build.*/kodi-*/.install_pkg/usr/share/kodi/**
+            build.*/kodi-*/.install_pkg/usr/bin/kodi*
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-log
+          path: build.*/.build.log
+          if-no-files-found: warn

--- a/packages/devel/glibc/patches/001-fix-statx-return-gcc13.patch
+++ b/packages/devel/glibc/patches/001-fix-statx-return-gcc13.patch
@@ -1,0 +1,13 @@
+Fix statx.c falling off the end when __NR_statx undefined but __ASSUME_STATX
+defined (a header/kernel mismatch that never happens in practice).  GCC 13's
+-Werror=return-type now catches this.  Add __builtin_unreachable to tell the
+compiler the path is dead code.
+
+--- a/sysdeps/unix/sysv/linux/statx.c
++++ b/sysdeps/unix/sysv/linux/statx.c
+@@ -38,4 +38,5 @@ statx (int fd, const char *path, int flags,
+ #ifndef __ASSUME_STATX
+   return statx_generic (fd, path, flags, mask, buf);
+ #endif
++  __builtin_unreachable ();
+ }

--- a/projects/Amlogic-ce/devices/Amlogic-ne/patches/kodi/001-dv-hvcc-passthrough.patch
+++ b/projects/Amlogic-ce/devices/Amlogic-ne/patches/kodi/001-dv-hvcc-passthrough.patch
@@ -1,0 +1,265 @@
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+index bfeb0ac5..cb74e555 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+@@ -306,6 +306,9 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
+       }
+       m_pFormatName = "am-h265";
+       m_bitstream = new CBitstreamConverter();
++      // Before Open(): tell the converter that this stream is DV, so it can engage the
++      // hvcC passthrough path if the extradata is in hvcC format.
++      m_bitstream->SetDoViHvccPassthrough(m_hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION);
+       m_bitstream->Open(m_hints.codec, m_hints.extradata.GetData(), m_hints.extradata.GetSize(), true);
+ 
+       if (m_hints.extradata && !m_hints.cryptoSession)
+diff --git a/xbmc/utils/BitstreamConverter.cpp b/xbmc/utils/BitstreamConverter.cpp
+index c1bac630..661ab0da 100644
+--- a/xbmc/utils/BitstreamConverter.cpp
++++ b/xbmc/utils/BitstreamConverter.cpp
+@@ -447,6 +447,24 @@ bool CBitstreamConverter::Open(enum AVCodecID codec, uint8_t *in_extradata, int
+ 
+         if (in_extradata[0] || in_extradata[1] || in_extradata[2] > 1)
+         {
++          // Dolby Vision HLS fmp4: the hvcC already contains VPS/SPS/PPS that the amstream
++          // kernel driver is happy with. Don't run the full HEVC bitstream filter (SPS/PPS
++          // carousel, SEI rewrite, RPU transform, HDR10+ conversion) -- any of those mutate
++          // NAL payloads in ways that break DV on S905X3. Instead build AnnexB extradata
++          // once here and switch Convert() to a byte-exact length->start-code rewrite.
++          if (m_dovi_hvcc_passthrough_requested && in_extradata[0] != 0)
++          {
++            if (BuildDoViAnnexbExtradataHEVC(in_extradata, in_extrasize))
++            {
++              m_dovi_hvcc_passthrough = true;
++              m_convert_bitstream = true; // so NeedConvert()/Convert() dispatches here
++              CLog::Log(LOGINFO, "CBitstreamConverter::Open DV hvcC passthrough enabled "
++                                 "-- packet per-NAL rewrite bypassed");
++              return true;
++            }
++            CLog::Log(LOGWARNING, "CBitstreamConverter::Open DV hvcC passthrough init "
++                                  "failed, falling back to standard HEVC filter");
++          }
+           CLog::Log(LOGINFO, "CBitstreamConverter::Open bitstream to annexb init");
+           m_extraData = FFmpegExtraData(in_extradata, in_extrasize);
+           m_convert_bitstream =
+@@ -516,6 +534,8 @@ void CBitstreamConverter::Close(void)
+   m_convert_bytestream = false;
+   m_convert_3byteTo4byteNALSize = false;
+   m_combine = false;
++  m_dovi_hvcc_passthrough = false;
++  m_dovi_length_size = 4;
+ }
+ 
+ bool CBitstreamConverter::Convert(uint8_t *pData, int iSize)
+@@ -545,7 +565,13 @@ bool CBitstreamConverter::Convert(uint8_t *pData, int iSize)
+           int bytestream_size = 0;
+           uint8_t *bytestream_buff = NULL;
+ 
+-          BitstreamConvert(demuxer_content, demuxer_bytes, &bytestream_buff, &bytestream_size);
++          if (m_dovi_hvcc_passthrough)
++          {
++            DoViHvccPassthroughConvert(demuxer_content, demuxer_bytes,
++                                       &bytestream_buff, &bytestream_size);
++          }
++          else
++            BitstreamConvert(demuxer_content, demuxer_bytes, &bytestream_buff, &bytestream_size);
+           if (bytestream_buff && (bytestream_size > 0))
+           {
+             m_convertSize   = bytestream_size;
+@@ -1045,6 +1071,155 @@ bool CBitstreamConverter::BitstreamConvertInitHEVC(void *in_extradata, int in_ex
+   return true;
+ }
+ 
++// Walk an hvcC atom, collect each VPS/SPS/PPS NAL, and emit an AnnexB-format blob
++// (VPS | SPS | PPS, each preceded by a 4-byte 00 00 00 01 start code) into m_extraData.
++// This is the DV-passthrough equivalent of BitstreamConvertInitHEVC but it does NOT
++// populate m_sps_pps_context (we never reinject parameter sets on IDR in passthrough
++// mode -- the segment's own VPS/SPS/PPS NALs ride in the packet stream).
++bool CBitstreamConverter::BuildDoViAnnexbExtradataHEVC(const uint8_t *in_extradata,
++                                                       int in_extrasize)
++{
++  if (!in_extradata || in_extrasize < 23)
++    return false;
++
++  // hvcC length-prefix width used for packet-level NALs (not the extradata NAL widths,
++  // which are always 16-bit inside the arrays).
++  m_dovi_length_size = (in_extradata[21] & 0x3) + 1;
++  if (m_dovi_length_size != 1 && m_dovi_length_size != 2 && m_dovi_length_size != 4)
++  {
++    CLog::Log(LOGERROR, "CBitstreamConverter::BuildDoViAnnexbExtradataHEVC invalid "
++                        "length_size=%d", m_dovi_length_size);
++    return false;
++  }
++
++  const uint8_t *p   = in_extradata + 22; // numOfArrays
++  const uint8_t *end = in_extradata + in_extrasize;
++  if (p >= end)
++    return false;
++
++  uint8_t array_nb = *p++;
++  static const uint8_t nalu_header[4] = {0, 0, 0, 1};
++
++  uint8_t *out = NULL;
++  uint32_t total_size = 0;
++
++  while (array_nb--)
++  {
++    if (p + 3 > end) { av_free(out); return false; }
++    /* uint8_t array_completeness = (*p >> 7) & 1; */
++    /* uint8_t nal_type = *p & 0x3f; */
++    p += 1;
++    uint16_t unit_nb = (p[0] << 8) | p[1];
++    p += 2;
++
++    while (unit_nb--)
++    {
++      if (p + 2 > end) { av_free(out); return false; }
++      uint16_t unit_size = (p[0] << 8) | p[1];
++      p += 2;
++      if (p + unit_size > end) { av_free(out); return false; }
++
++      uint32_t new_size = total_size + 4 + unit_size;
++      if (new_size > (uint32_t)(INT_MAX - AV_INPUT_BUFFER_PADDING_SIZE))
++      {
++        av_free(out);
++        return false;
++      }
++      void *tmp = av_realloc(out, new_size + AV_INPUT_BUFFER_PADDING_SIZE);
++      if (!tmp) { av_free(out); return false; }
++      out = (uint8_t*)tmp;
++
++      memcpy(out + total_size, nalu_header, 4);
++      memcpy(out + total_size + 4, p, unit_size);
++      total_size = new_size;
++      p += unit_size;
++    }
++  }
++
++  if (!out || total_size == 0)
++    return false;
++
++  memset(out + total_size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
++
++  m_extraData = FFmpegExtraData(out, total_size);
++  av_free(out);
++
++  CLog::Log(LOGINFO, "CBitstreamConverter::BuildDoViAnnexbExtradataHEVC built %u bytes "
++                     "of AnnexB extradata (length_size=%u)",
++            total_size, m_dovi_length_size);
++  return true;
++}
++
++// Byte-exact hvcC->AnnexB rewrite for a single packet. Every length-prefixed NAL in
++// pData has its length field replaced with 00 00 00 01; NAL bodies are copied verbatim
++// (including RPU NAL 62, SEI NAL 39/40, VPS/SPS/PPS). No SPS/PPS carousel. No SEI mangle.
++// No RPU transform. Bounds-checked against iSize on every step.
++bool CBitstreamConverter::DoViHvccPassthroughConvert(const uint8_t *pData, int iSize,
++                                                     uint8_t **poutbuf, int *poutbuf_size)
++{
++  *poutbuf = NULL;
++  *poutbuf_size = 0;
++  if (!pData || iSize <= 0)
++    return false;
++
++  const uint8_t ls = m_dovi_length_size ? m_dovi_length_size : 4;
++  if (ls != 1 && ls != 2 && ls != 4)
++    return false;
++
++  // Worst case: every NAL has ls == 4 and maps 1:1 to a 4-byte start code, so output is
++  // exactly iSize. For ls < 4 the output would grow, but hvcC in practice is always 4.
++  const size_t out_cap = (size_t)iSize + (size_t)iSize; // generous headroom for ls<4
++  uint8_t *out = (uint8_t*)av_malloc(out_cap + AV_INPUT_BUFFER_PADDING_SIZE);
++  if (!out)
++    return false;
++
++  size_t out_pos = 0;
++  const uint8_t *p = pData;
++  const uint8_t *end = pData + iSize;
++  static const uint8_t start_code[4] = {0, 0, 0, 1};
++
++  while (p < end)
++  {
++    if (p + ls > end)
++    {
++      CLog::Log(LOGERROR, "CBitstreamConverter::DoViHvccPassthroughConvert truncated "
++                          "length field at offset %ld", (long)(p - pData));
++      av_free(out);
++      return false;
++    }
++    uint32_t nal_size = 0;
++    for (uint8_t i = 0; i < ls; ++i)
++      nal_size = (nal_size << 8) | p[i];
++    p += ls;
++
++    if (nal_size == 0)
++      continue;
++    if (p + nal_size > end)
++    {
++      CLog::Log(LOGERROR, "CBitstreamConverter::DoViHvccPassthroughConvert NAL size %u "
++                          "overruns packet (remaining %ld)",
++                nal_size, (long)(end - p));
++      av_free(out);
++      return false;
++    }
++    if (out_pos + 4 + nal_size > out_cap)
++    {
++      av_free(out);
++      return false;
++    }
++    memcpy(out + out_pos, start_code, 4);
++    out_pos += 4;
++    memcpy(out + out_pos, p, nal_size);
++    out_pos += nal_size;
++    p += nal_size;
++  }
++
++  memset(out + out_pos, 0, AV_INPUT_BUFFER_PADDING_SIZE);
++  *poutbuf = out;
++  *poutbuf_size = (int)out_pos;
++  return true;
++}
++
+ bool CBitstreamConverter::IsIDR(uint8_t unit_type)
+ {
+   switch (m_codec)
+diff --git a/xbmc/utils/BitstreamConverter.h b/xbmc/utils/BitstreamConverter.h
+index 023d8559..cc19229b 100644
+--- a/xbmc/utils/BitstreamConverter.h
++++ b/xbmc/utils/BitstreamConverter.h
+@@ -131,6 +131,10 @@ public:
+   void              ResetStartDecode(void);
+   bool              CanStartDecode() const;
+   void SetConvertDovi(enum DOVIMode value) { m_convert_dovi = value; }
++  // Hint from the caller (e.g. CDVDVideoCodecAmlogic) that this stream's hdrType is
++  // Dolby Vision. Must be called BEFORE Open(). Enables hvcC->AnnexB byte-exact
++  // passthrough so SEI/RPU/SPS-PPS mangling cannot corrupt DV NAL payloads.
++  void SetDoViHvccPassthrough(bool value) { m_dovi_hvcc_passthrough_requested = value; }
+   void SetRemoveDovi(bool value) { m_removeDovi = value; }
+   void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
+   void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
+@@ -148,6 +152,12 @@ protected:
+   bool              IsSlice(uint8_t unit_type);
+   bool              BitstreamConvertInitAVC(void *in_extradata, int in_extrasize);
+   bool              BitstreamConvertInitHEVC(void *in_extradata, int in_extrasize);
++  // Dolby Vision hvcC passthrough: build AnnexB-form extradata (VPS/SPS/PPS) once from
++  // hvcC, and perform a byte-exact length-prefix -> start-code rewrite on each packet
++  // with no SEI/RPU/HDR10+ processing and no SPS/PPS carousel.
++  bool              BuildDoViAnnexbExtradataHEVC(const uint8_t *in_extradata, int in_extrasize);
++  bool              DoViHvccPassthroughConvert(const uint8_t *pData, int iSize,
++                                               uint8_t **poutbuf, int *poutbuf_size);
+   bool              BitstreamConvert(uint8_t* pData, int iSize, uint8_t **poutbuf, int *poutbuf_size);
+   static void BitstreamAllocAndCopy(uint8_t** poutbuf,
+                                     int* poutbuf_size,
+@@ -195,4 +205,13 @@ protected:
+   bool              m_removeHdr10Plus;
+   bool              m_setDoviZeroLevel5;
+   enum ELType       m_dovi_el_type;
++
++  // When true, bypass the full HEVC bitstream filter (no SPS/PPS carousel, no SEI / RPU /
++  // HDR10+ processing) and simply rewrite length-prefix fields to 4-byte AnnexB start
++  // codes. Used for HLS fmp4 Dolby Vision where the hvcC-format sample entries already
++  // contain all the metadata the amstream kernel driver needs and any SEI/RPU mangling
++  // breaks DV output on the S905X3.
++  bool              m_dovi_hvcc_passthrough_requested = false;
++  bool              m_dovi_hvcc_passthrough = false;
++  uint8_t           m_dovi_length_size = 4;
+ };


### PR DESCRIPTION
# HLS fmp4 Dolby Vision HEVC stalls with zero frames while matroska with identical bitstream plays correctly

## Summary

On CoreELEC-Amlogic builds based on `aml-4.9-21.3`, a fragmented-MP4 HLS stream containing HEVC + Dolby Vision (verified with Profile 8, Level 6, BL=1 EL=0 RPU=1, cross-compatible ID=1) successfully opens the Amlogic HW decoder, engages the full DV pipeline (`aml_dv_open`, IPT Tunnel, PQ transfer, HDMI DV mode negotiation, TrueHD passthrough audio), downloads all segments, and then produces **zero frames**. The `CVideoPlayerAudio::Process` thread reports `stream stalled` after ~30s and the player crashes.

The **identical video bitstream** delivered via an `ffmpeg → named pipe → matroska` path on the same box plays flawlessly with full DV engagement.

This issue isolates the divergence to `BitstreamConverter::Open()` in `xbmc/utils/BitstreamConverter.cpp`, and proposes a minimal fix.

## Environment

- **Box**: UGOOS AM6B (Amlogic S922X, rev b)
- **CoreELEC**: `Amlogic-ng.arm-21.3-Omega_p3i_T3b_20260322020632` (pannal p3i build)
- **Kernel**: 4.9.269 aarch64 (32-bit Kodi userspace on 64-bit kernel)
- **Kodi**: built from `pannal/xbmc` branch `aml-4.9-21.3`
- **Display**: Dolby Vision-capable TV over HDMI, DV mode advertised and negotiated (verified in log)
- **Source content**: HEVC Main10 + DV Profile 8.1 (BL=1 EL=0 RPU=1, cross-compatible ID=1), TrueHD 5.1 audio

## Reproduction

1. Take any HEVC P8.1 + TrueHD Matroska source that plays correctly via normal Kodi playback.
2. Remux to fragmented MP4 HLS:
   ```
   ffmpeg -fflags +fastseek -i INPUT.mkv \
     -map 0:v:0 -map 0:a \
     -c:v copy -c:a copy -sn -copyts \
     -strict -2 -tag:v hvc1 \
     -f hls -hls_time 6 -hls_segment_type fmp4 \
     -hls_fmp4_init_filename init.mp4 \
     -hls_segment_filename seg_%06d.m4s \
     -hls_playlist_type vod -hls_flags independent_segments \
     playlist.m3u8
   ```
3. Note ffmpeg 6.x's HLS muxer **strips the `dvvC` box** from the init segment (this is a separate upstream ffmpeg bug — workaround: inject `dvvC` manually into `init.mp4` after ffmpeg writes it; code available, happy to share). Without the `dvvC` box, `hints.hdrType` stays `HDR_TYPE_NONE` and nothing below applies — so this step is required just to reach the bug.
4. Serve the segments over HTTP and play the playlist through Kodi.
5. Observe: `aml_dv_open`, IPT Tunnel, PQ transfer, HDMI DV all engage; all segments download; zero frames produced; stream stalls; player crashes.

Compare against: the same source fed to Kodi via an ffmpeg → named pipe → matroska path on the same box. Works perfectly.

## Analysis: where the paths diverge

Both routes enter `CDVDVideoCodecAmlogic::Open()`, which unconditionally constructs `CBitstreamConverter(m_hints)` and calls `Open(true)`:

- `xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp:307-308`

Divergence happens inside `BitstreamConverter::Open()` based on the shape of `hints.extradata`:

| Step | HLS fmp4 (broken) | Matroska pipe (works) |
|---|---|---|
| `hints.extradata` format | length-prefixed `hvcC` (mov demuxer) | AnnexB (ffmpeg matroska demuxer emits CodecPrivate as-is) |
| `BitstreamConverter.cpp:643` — `extradata[0] \|\| extradata[1] \|\| extradata[2] > 1` | **true** | false |
| `:645` log | `"bitstream to annexb init"` | — |
| `:647` → `BitstreamConvertInitHEVC` | runs, builds SPS/PPS prefix blob (strips non-parameter-set NALs at `:1130-1136`) | skipped |
| `:687` return | — | `return false` |
| `m_convert_bitstream` | `true` | stays `false` |
| Per-packet `Convert()` behavior | `BitstreamConvert()` per-NAL rewrite (`:1448-1516`), prepends SPS/PPS on every IDR (`:1477-1482`), re-serializes RPU via `ProcessDoViRpu` (`:1498-1501`), mixed 3/4-byte start codes (`:1545 vs :1550`) | passthrough (`:758-762`, `m_inputBuffer = pData`) |
| Bytes to `CAMLCodec::AddData` / `codec_write` | reassembled AnnexB | original packet bytes, untouched |

Both paths call `aml_dv_open(hints.hdrType, hints.bitdepth, hints.colorPrimaries)` (`AMLCodec.cpp:2092`) identically. `aml_dv_open` receives only scalars, not buffers — so the DV engagement is byte-independent. The difference is entirely in what ES bytes reach the kernel amstream fd.

## Hypothesized root causes

Two candidate mechanisms are consistent with "opens, 30s wait, zero frames, stall":

### H1: parameter-set carousel on every IDR breaks the active DV pipeline

`BitstreamConvert()` re-prepends VPS/SPS/PPS to every IDR access unit (`BitstreamConverter.cpp:1477-1482`). The matroska pipe path never does this — it passes the packet bytes through untouched, so parameter sets appear only where the remuxer originally placed them.

The Amlogic amvideo kernel driver with DV IPT-tunnel engaged (`aml_dv_send_el_type`, `aml_dv_send_profile`) may not tolerate parameter-set change events inside an active DV session, silently dropping all frames until the next decoder reset.

### H2: RPU NAL reconstruction is not byte-identical

`ProcessDoViRpu` rewrites NAL 62 with a forced 4-byte start code at `BitstreamConverter.cpp:1550-1551`, while adjacent NALs in the same AU use 3-byte separators (`:1545`). This is a valid AnnexB bytestream per spec — but the amvideo DV firmware gates frame emission on RPU byte-position relative to the slice header, so a bit-exact match between "what the encoder laid down" and "what the decoder sees" may be required.

The matroska passthrough path preserves the exact RPU position and start-code widths the encoder emitted; the per-NAL reassembly path cannot guarantee that.

## Proposed fix

**Short-circuit the per-NAL rewrite when the stream is Dolby Vision and the extradata is `hvcC`-format**: pre-convert the extradata to AnnexB once at `Open()` time (so `CAMLCodec::hevc_add_header` still gets a valid AnnexB SPS/VPS/PPS blob), then set `m_convert_bitstream = false` so packet bodies pass through unmodified.

Pseudocode sketch, at `BitstreamConverter::Open()` for HEVC in `xbmc/utils/BitstreamConverter.cpp`:

```cpp
if (m_to_annexb && codec == AV_CODEC_ID_HEVC &&
    (in_extradata[0] || in_extradata[1] || in_extradata[2] > 1))
{
  // Pannal DV passthrough: if this is a DV stream, the per-NAL rewrite path
  // breaks Amlogic DV pipeline (parameter-set carousel on every IDR + RPU
  // byte-position changes). Convert extradata once, then let packets pass
  // through untouched.
  if (m_hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
  {
    if (!ConvertHvcCToAnnexB(in_extradata, in_extrasize,
                             &m_extraData, &m_extraSize))
      return false;
    m_convert_bitstream = false;        // force passthrough in Convert()
    CLog::Log(LOGINFO, "CBitstreamConverter::Open DV hvcC passthrough "
                       "(extradata converted once, packet bodies untouched)");
    return true;
  }
  // ... existing hvcC → per-NAL init path
}
```

`ConvertHvcCToAnnexB` would walk the hvcC structure, emit `00 00 00 01 <NAL>` for each VPS/SPS/PPS unit, and write the result into `m_extraData`. The existing `BitstreamConvertInitHEVC` already knows how to walk hvcC arrays; most of that logic can be factored out.

This fix assumes the demuxer is delivering length-prefixed NAL bodies in packets. For pure fmp4/mov HEVC, that is always the case — ffmpeg's mov demuxer emits the sample data as stored, which is length-prefixed per ISO/IEC 14496-15. The Amlogic kernel ES fd would then receive length-prefixed NAL bodies, which is **wrong** for `am-h265` (it expects AnnexB). So a simple "clear `m_convert_bitstream` and passthrough" is insufficient — packet bodies also need length-prefix → start-code conversion, **without** re-prepending parameter sets on every IDR and **without** touching RPU bytes beyond the 4-byte length field.

Refined proposal:

```cpp
// New DOVIMode (or flag) for pannal's DOVIMode enum:
DOVIMode::MODE_PASSTHROUGH_HVCC
```

When set, `Convert()` should:
1. Walk the length-prefixed NAL stream in `pData`.
2. Replace each 4-byte length field with `00 00 00 01` (or `00 00 01`).
3. **Not** re-prepend SPS/PPS on IDR.
4. **Not** route NAL 62 through `ProcessDoViRpu` — copy it verbatim.
5. **Not** touch SEI or HDR10+ at all.

This preserves the encoder's exact NAL ordering and start-code pattern inside each AU, and avoids the `BitstreamConvertInitHEVC` parameter-set stripping. `DVDVideoCodecAmlogic::Open` would select this mode when `hints.hdrType == HDR_TYPE_DOLBYVISION` and extradata is `hvcC`.

## Alternatives considered

- **Expose `m_convert_bitstream` passthrough via a Kodi setting** so users can toggle it from the GUI without a rebuild. Workable but a hidden knob; a correct default is better.
- **Detect the divergence at the demuxer level** and have `DVDDemuxFFmpeg` pre-convert HEVC extradata + packets to AnnexB for Amlogic DV streams. Higher impact, cross-cuts non-DV paths.
- **Fix it in ffmpeg's HLS muxer** so it emits AnnexB-style samples. Not a valid fmp4 — rejected by every other HLS consumer.

## What I can contribute

- Self-contained reproduction: HLS fmp4 test vectors (init + segments + playlist) with injected `dvvC`, plus a standalone Python script that performs the injection against any ffmpeg-produced HLS init segment.
- Kodi log excerpts from both broken (fmp4 HLS) and working (matroska pipe) paths on the same box with the same source, with `setextraloglevel=128` enabled.
- Happy to test a prototype patch — I have SSH access to the test box and can iterate quickly.

## Related

- ffmpeg 6.x HLS muxer drops `dvvC` from fmp4 init segments (separate upstream bug; worked around locally by post-processing). The same ffmpeg with `-f mp4` writes `dvvC` correctly — the bug is isolated to the HLS muxer's init-write path, not the mov muxer.
- This affects any project trying to deliver DV-over-HLS to CoreELEC-Amlogic boxes (e.g., Jellyfin transcoders, custom Kodi players).

---

*Filed against `pannal/xbmc` branch `aml-4.9-21.3` after tracing the code path with multiple source-diff passes against upstream xbmc/xbmc 21.2-Omega. Happy to answer follow-up questions and test patches.*
