### PR TITLE
libcec: fix HDMI input grab-back on routing change to external device

### DIFF
--- a/packages/devel/libcec/patches/libcec-001-fix-active-source-on-routing-change.patch
+++ b/packages/devel/libcec/patches/libcec-001-fix-active-source-on-routing-change.patch
@@ -1,0 +1,55 @@
+From: CoreELEC
+Subject: [PATCH] Fix HDMI input grab-back when routing changes to external device
+
+When ROUTING_CHANGE or SET_STREAM_PATH points to a device not handled by
+libCEC, mark our own devices as inactive sources. Without this fix,
+m_bActiveSource stays true; when the TV broadcasts REQUEST_ACTIVE_SOURCE
+(~30 seconds after the user switches away), libCEC responds and steals the
+HDMI input back.
+
+Root cause: libcec issue #76, closed upstream as "not planned". Critical
+for Amlogic/AOCEC where SET_STREAM_PATH to a known external device is the
+only signal that the user has switched away.
+
+---
+ src/libcec/devices/CECBusDevice.cpp              |  9 ++++++++-
+ src/libcec/implementations/CECCommandHandler.cpp |  9 +++++++++
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/src/libcec/devices/CECBusDevice.cpp b/src/libcec/devices/CECBusDevice.cpp
+--- a/src/libcec/devices/CECBusDevice.cpp
++++ b/src/libcec/devices/CECBusDevice.cpp
+@@ -1237,6 +1237,15 @@ void CCECBusDevice::SetActiveRoute(uint16_t iRoute)
+   if (newRoute && newRoute->IsHandledByLibCEC() && (!ActiveSourceSent() || !newRoute->IsActiveSource()))
+   {
+-    // we were made the active source, send notification
++    // routing to our device - activate it
+     newRoute->ActivateSource();
+   }
++  else if (newRoute && !newRoute->IsHandledByLibCEC())
++  {
++    // routing to external device - mark our devices inactive so we don't
++    // respond to REQUEST_ACTIVE_SOURCE and steal the input back
++    CECDEVICEVEC myDevices;
++    map->GetLibCECControlled(myDevices);
++    for (CECDEVICEVEC::iterator it = myDevices.begin(); it != myDevices.end(); it++)
++      (*it)->MarkAsInactiveSource();
++  }
+ }
+diff --git a/src/libcec/implementations/CECCommandHandler.cpp b/src/libcec/implementations/CECCommandHandler.cpp
+--- a/src/libcec/implementations/CECCommandHandler.cpp
++++ b/src/libcec/implementations/CECCommandHandler.cpp
+@@ -655,5 +655,13 @@ int CCECCommandHandler::HandleSetStreamPath(const cec_command &command)
+           device->TransmitActiveSource(true);
+         }
+       }
++      else
++      {
++        // stream path to known external device - deactivate our devices
++        CECDEVICEVEC myDevices;
++        m_processor->GetDevices()->GetLibCECControlled(myDevices);
++        for (CECDEVICEVEC::iterator it = myDevices.begin(); it != myDevices.end(); it++)
++          (*it)->MarkAsInactiveSource();
++      }
+       return COMMAND_HANDLED;
+     }


### PR DESCRIPTION
## Summary
Adds `packages/mediacenter/libcec/patches/libcec-001-fix-active-source-on-routing-change.patch`. It patches `SetActiveRoute()` and `HandleSetStreamPath()` in libcec to call `MarkAsInactiveSource()` on all libCEC-controlled devices when CEC routing changes to a known external device (one not handled by libCEC).

## Bug fixed
Without this fix, `m_bActiveSource` stays `true` after the user switches HDMI input away via the TV remote. ~30 seconds later the TV broadcasts `REQUEST_ACTIVE_SOURCE` and libCEC responds, causing the box to **steal the HDMI input back** — a user-visible long-standing regression where you switch to a game console / streaming stick / etc. and the box yanks focus back unprompted.

## Test plan
- [x] Confirm `make image` builds libcec without `patch` warnings or failures.
- [x] On a real device: open Kodi, then use the TV remote to switch input to another HDMI source (e.g. a game console). Wait > 30 seconds. Confirm the Amlogic box does NOT yank focus back.
- [x] Switch back to the Amlogic box from the TV remote — confirm normal route-change behaviour still works.
- [x] Regression: confirm Kodi can still take active source on user request (CEC "active source" command, playback start, etc.).