### PR TITLE
wireguard-linux-compat: refresh snapshot checksum

### DIFF
--- a/packages/network/wireguard-linux-compat/package.mk
+++ b/packages/network/wireguard-linux-compat/package.mk
@@ -4,7 +4,7 @@
 
 PKG_NAME="wireguard-linux-compat"
 PKG_VERSION="1.0.20220627"
-PKG_SHA256="362d412693c8fe82de00283435818d5c5def7f15e2433a07a9fe99d0518f63c0"
+PKG_SHA256="19b181e5c7d2260c23ecad4ad324425fd8e88200d97a885a2c7d4bd26cd61461"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
The upstream wireguard-linux-compat snapshot tarball for 1.0.20220627 currently resolves to a different archive checksum than previously pinned. This updates PKG_SHA256 to the newly served value so source fetch and unpack succeed again.

Scope:

packages/network/wireguard-linux-compat/package.mk only
Validation:

scripts/install wireguard-linux-compat:target now completes fetch, unpack, build, and install stages successfully.