### PR TITLE
avahi: run autogen.sh from PKG_BUILD

### DIFF
--- a/packages/network/avahi/package.mk
+++ b/packages/network/avahi/package.mk
@@ -57,7 +57,7 @@ PKG_CONFIGURE_OPTS_TARGET="py_cv_mod_gtk_=yes \
                            --disable-nls"
 
 pre_configure_target() {
-  NOCONFIGURE=1 ./autogen.sh
+  NOCONFIGURE=1 ${PKG_BUILD}/autogen.sh
 }
 
 post_configure_target() {


### PR DESCRIPTION
Fix avahi pre_configure_target to invoke autogen.sh using ${PKG_BUILD} instead of a relative path.

Reason:

The build hook does not always run from the extracted source directory.
./autogen.sh can fail with “No such file or directory”.
Change:

NOCONFIGURE=1 ./autogen.sh
NOCONFIGURE=1 ${PKG_BUILD}/autogen.sh
Validation:

PROJECT=Amlogic-ce DEVICE=Amlogic-ng ARCH=arm scripts/install avahi:target now exits successfully in the pannal tree.