### PR TITLE
libcec: add 5s cooldown to routing change wake-up

### DIFF
--- a/packages/devel/libcec/patches/libcec-001-fix-active-source-on-routing-change.patch
+++ b/packages/devel/libcec/patches/libcec-001-fix-active-source-on-routing-change.patch
@@ -19,12 +19,27 @@ only signal that the user has switched away.
 diff --git a/src/libcec/devices/CECBusDevice.cpp b/src/libcec/devices/CECBusDevice.cpp
 --- a/src/libcec/devices/CECBusDevice.cpp
 +++ b/src/libcec/devices/CECBusDevice.cpp
-@@ -1237,6 +1237,15 @@ void CCECBusDevice::SetActiveRoute(uint16_t iRoute)
+@@ -1237,6 +1237,29 @@ void CCECBusDevice::SetActiveRoute(uint16_t iRoute)
    if (newRoute && newRoute->IsHandledByLibCEC() && (!ActiveSourceSent() || !newRoute->IsActiveSource()))
    {
 -    // we were made the active source, send notification
-+    // routing to our device - activate it
-     newRoute->ActivateSource();
+-    newRoute->ActivateSource();
++    bool bSkipActivate = false;
++    CCECBusDevice* tv = map->At(CECDEVICE_TV);
++    if (tv)
++    {
++      cec_power_status tvStatus = tv->GetCurrentPowerStatus();
++      if ((tvStatus == CEC_POWER_STATUS_STANDBY || tvStatus == CEC_POWER_STATUS_IN_TRANSITION_ON_TO_STANDBY) &&
++          (GetTimeMs() - tv->m_iLastPowerStateUpdate < 5000))
++      {
++        bSkipActivate = true;
++      }
++    }
++    if (!bSkipActivate)
++    {
++      // routing to our device - activate it
++      newRoute->ActivateSource();
++    }
    }
 +  else if (newRoute && !newRoute->IsHandledByLibCEC())
 +  {


### PR DESCRIPTION
User Enky on Discord reported an issue where, with the option for "When the TV is switched off" set to "Stop", he powered off his TV during playback of a TV show and the TV and AVR turned off, playback stopped, but then the Ugoos woke the TV and AVR back up immediately. He provided 2 log files that I'm attaching for posterity. The one that had the interesting data was the stop on shutdown. 

On inspection of his logs, the AVR was sending a source routing change when it powered down about 1.5 seconds after the TV had sent its standby broadcast. This PR introduces a check to see if a TV standby CEC broadcast was received within 5 seconds of a source routing change command before passing an activate source command. Enky has reported it fixed his issue with a test build.

[log with setting to stop on shutdown.txt](https://github.com/user-attachments/files/30248245/log.with.setting.to.stop.on.shutdown.txt)
[log with setting to ignore on shutdown.txt](https://github.com/user-attachments/files/30248244/log.with.setting.to.ignore.on.shutdown.txt)