### PR TITLE
ffmpeg: import AC-4 audio decoder and parser from librempeg

### DIFF
--- a/packages/multimedia/ffmpeg/patches/0007-add-ac4-decoder-parser-from-librempeg.patch
+++ b/packages/multimedia/ffmpeg/patches/0007-add-ac4-decoder-parser-from-librempeg.patch
@@ -1,131 +1,23 @@
-diff --git a/custom-edits.patch b/custom-edits.patch
-new file mode 100644
-index 0000000000..93140f778c
---- /dev/null
-+++ b/custom-edits.patch
-@@ -0,0 +1,30 @@
-+diff --git a/libavcodec/ac4dec.c b/libavcodec/ac4dec.c
-+index 27b8a037e9..ff2ff4739c 100644
-+--- a/libavcodec/ac4dec.c
-++++ b/libavcodec/ac4dec.c
-+@@ -32,6 +32,16 @@
-+ #include "libavutil/opt.h"
-+ 
-+ #include "ac4dec_data.h"
-++
-++static void ac4_vector_fmul_reverse_c(float *dst, const float *src0,
-++                                      const float *src1, int len)
-++{
-++    int i;
-++    src1 += len - 1;
-++    for (i = 0; i < len; i++)
-++        dst[i] = src0[i] * src1[-i];
-++}
-++
-+ #include "avcodec.h"
-+ #include "get_bits.h"
-+ #include "codec_internal.h"
-+@@ -5390,7 +5400,7 @@ static void spectral_synthesis(AC4DecodeContext *s, SubstreamChannel *ssch)
-+                 s->fdsp->vector_fmul_reverse(overlap + nskip_prev,
-+                                              overlap + nskip_prev, swinr, N_prev);
-+             else
-+-                ff_vector_fmul_reverse_c(overlap + nskip_prev,
-++                ac4_vector_fmul_reverse_c(overlap + nskip_prev,
-+                                          overlap + nskip_prev, swinr, N_prev);
-+ 
-+             for (int n = 0; n < N; n++)
-diff --git a/inject-ac4.sh b/inject-ac4.sh
-new file mode 100755
-index 0000000000..b8b5de4b2e
---- /dev/null
-+++ b/inject-ac4.sh
-@@ -0,0 +1,66 @@
-+#!/bin/bash
-+set -e
-+
-+echo "Downloading AC-4 DSP files from librempeg..."
-+curl -sL https://raw.githubusercontent.com/librempeg/librempeg/master/libavcodec/ac4dec.c > libavcodec/ac4dec.c
-+curl -sL https://raw.githubusercontent.com/librempeg/librempeg/master/libavcodec/ac4dec_data.h > libavcodec/ac4dec_data.h
-+curl -sL https://raw.githubusercontent.com/librempeg/librempeg/master/libavcodec/ac4_parser.c > libavcodec/ac4_parser.c
-+
-+echo "Applying custom DSP edits..."
-+git apply custom-edits.patch
-+
-+echo "Applying FFmpeg static glue..."
-+
-+# libavcodec/Makefile
-+if ! grep -q "ac4dec.o" libavcodec/Makefile; then
-+    sed -i '/OBJS-$(CONFIG_AC3_DECODER)/a OBJS-$(CONFIG_AC4_DECODER)             += ac4dec.o' libavcodec/Makefile
-+fi
-+if ! grep -q "ac4_parser.o" libavcodec/Makefile; then
-+    sed -i '/OBJS-$(CONFIG_AC3_PARSER)/a OBJS-$(CONFIG_AC4_PARSER)              += ac4_parser.o' libavcodec/Makefile
-+fi
-+
-+# libavcodec/allcodecs.c
-+if ! grep -q "&ff_ac4_decoder" libavcodec/allcodecs.c; then
-+    sed -i '/&ff_ac3_decoder/a \    extern const FFCodec ff_ac4_decoder;' libavcodec/allcodecs.c
-+fi
-+
-+# libavcodec/kbdwin.h
-+if ! grep -q "av_cold void ff_kbd_window_init" libavcodec/kbdwin.h; then
-+    sed -i 's/void ff_kbd_window_init/av_cold void ff_kbd_window_init/' libavcodec/kbdwin.h
-+fi
-+
-+# libavcodec/parsers.c
-+if ! grep -q "&ff_ac4_parser" libavcodec/parsers.c; then
-+    sed -i '/&ff_ac3_parser/a \    extern const AVCodecParser ff_ac4_parser;' libavcodec/parsers.c
-+fi
-+
-+# libavformat/mpegts.c
-+if ! grep -q "AV_CODEC_ID_AC4.*ATSC 3.0" libavformat/mpegts.c; then
-+    sed -i '/{ 0xac, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC3 }/a \    { 0xae, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 }, /* ATSC 3.0 */' libavformat/mpegts.c
-+fi
-+if ! grep -q "ac-4.*AVMEDIA_TYPE_AUDIO" libavformat/mpegts.c; then
-+    sed -i '/MKTAG('\''a'\'', '\''c'\'', '\''-'\'', '\''3'\'')/a \    { MKTAG('\''a'\'', '\''c'\'', '\''-'\'', '\''4'\''), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 },' libavformat/mpegts.c
-+    sed -i '/MKTAG('\''A'\'', '\''C'\'', '\''-'\'', '\''3'\'')/a \    { MKTAG('\''A'\'', '\''C'\'', '\''-'\'', '\''4'\''), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 },' libavformat/mpegts.c
-+fi
-+
-+# DVB Extension Descriptor parsing for ATSC 3.0 AC-4 streams
-+if ! grep -q "ext_desc_tag == 0x15.*AV_CODEC_ID_AC4" libavformat/mpegts.c; then
-+    sed -i '/if (ext_desc_tag < 0)/{
-+n
-+a\
-+        if (st->codecpar->codec_id == AV_CODEC_ID_BIN_DATA &&\
-+            ext_desc_tag == 0x15) {\
-+            st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;\
-+            st->codecpar->codec_id = AV_CODEC_ID_AC4;\
-+        }
-+    }' libavformat/mpegts.c
-+fi
-+
-+echo "Staging files..."
-+git add libavcodec/ac4dec.c libavcodec/ac4dec_data.h libavcodec/ac4_parser.c
-+git add libavcodec/Makefile libavcodec/allcodecs.c libavcodec/kbdwin.h libavcodec/parsers.c libavformat/mpegts.c
-+
-+if ! git diff --cached --quiet; then
-+    git commit -m "ffmpeg: Inject AC-4 decoder from librempeg"
-+fi
-+echo "AC-4 injection complete."
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 1410bd8142..9deea30d14 100644
+index 1410bd8142..854d2d9fbb 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -212,6 +212,7 @@ OBJS-$(CONFIG_AAC_MEDIACODEC_DECODER)  += mediacodecdec.o
+@@ -211,6 +211,7 @@ OBJS-$(CONFIG_AAC_ENCODER)             += aacenc.o aaccoder.o aacenctab.o    \
+ OBJS-$(CONFIG_AAC_MEDIACODEC_DECODER)  += mediacodecdec.o
  OBJS-$(CONFIG_AAC_MF_ENCODER)          += mfenc.o mf_utils.o
  OBJS-$(CONFIG_AASC_DECODER)            += aasc.o msrledec.o
- OBJS-$(CONFIG_AC3_DECODER)             += ac3dec_float.o ac3dec_data.o ac3.o \
 +OBJS-$(CONFIG_AC4_DECODER)             += ac4dec.o
+ OBJS-$(CONFIG_AC3_DECODER)             += ac3dec_float.o ac3dec_data.o ac3.o \
                                            kbdwin.o ac3tab.o ac3_channel_layout_tab.o
  OBJS-$(CONFIG_AC3_FIXED_DECODER)       += ac3dec_fixed.o ac3dec_data.o ac3.o \
-                                           kbdwin.o ac3tab.o ac3_channel_layout_tab.o
-@@ -1238,6 +1239,7 @@ OBJS-$(CONFIG_LIBZVBI_TELETEXT_DECODER)   += libzvbi-teletextdec.o ass.o
+@@ -1237,6 +1238,7 @@ OBJS-$(CONFIG_LIBZVBI_TELETEXT_DECODER)   += libzvbi-teletextdec.o ass.o
+ # parsers
  OBJS-$(CONFIG_AAC_LATM_PARSER)         += latm_parser.o
  OBJS-$(CONFIG_AAC_PARSER)              += aac_parser.o aac_ac3_parser.o
- OBJS-$(CONFIG_AC3_PARSER)              += aac_ac3_parser.o ac3tab.o \
 +OBJS-$(CONFIG_AC4_PARSER)              += ac4_parser.o
+ OBJS-$(CONFIG_AC3_PARSER)              += aac_ac3_parser.o ac3tab.o \
                                            ac3_channel_layout_tab.o
  OBJS-$(CONFIG_ADX_PARSER)              += adx_parser.o
- OBJS-$(CONFIG_AHX_PARSER)              += ahx_parser.o
 diff --git a/libavcodec/ac4_parser.c b/libavcodec/ac4_parser.c
 new file mode 100644
 index 0000000000..1ad425f0cf
@@ -8700,41 +8592,76 @@ index 0000000000..1eb24b22f2
 +};
 +
 +#endif /* AVCODEC_AC4DEC_DATA_H */
+diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
+index 695214f192..37907aa0a1 100644
+--- a/libavcodec/allcodecs.c
++++ b/libavcodec/allcodecs.c
+@@ -436,6 +436,7 @@ extern const FFCodec ff_aac_fixed_decoder;
+ extern const FFCodec ff_aac_latm_decoder;
+ extern const FFCodec ff_ac3_encoder;
+ extern const FFCodec ff_ac3_decoder;
++extern const FFCodec ff_ac4_decoder;
+ extern const FFCodec ff_ac3_fixed_encoder;
+ extern const FFCodec ff_ac3_fixed_decoder;
+ extern const FFCodec ff_acelp_kelvin_decoder;
 diff --git a/libavcodec/kbdwin.h b/libavcodec/kbdwin.h
-index 4185c4206f..9c43a6eedf 100644
+index 4185c4206f..2ea35e1bd5 100644
 --- a/libavcodec/kbdwin.h
 +++ b/libavcodec/kbdwin.h
-@@ -32,7 +32,7 @@
-  * @param   alpha   determines window shape
-  * @param   n       size of half window, max FF_KBD_WINDOW_MAX
+@@ -24,7 +24,7 @@
+ /**
+  * Maximum window size for ff_kbd_window_init.
   */
--void ff_kbd_window_init(float *window, float alpha, int n);
--void ff_kbd_window_init_fixed(int32_t *window, float alpha, int n);
-+av_cold void ff_kbd_window_init(float *window, float alpha, int n);
-+av_cold void ff_kbd_window_init_fixed(int32_t *window, float alpha, int n);
+-#define FF_KBD_WINDOW_MAX 1024
++#define FF_KBD_WINDOW_MAX 2048
  
- #endif /* AVCODEC_KBDWIN_H */
+ /**
+  * Generate a Kaiser-Bessel Derived Window.
+diff --git a/libavcodec/parsers.c b/libavcodec/parsers.c
+index 162b96cb69..d5ddeed7af 100644
+--- a/libavcodec/parsers.c
++++ b/libavcodec/parsers.c
+@@ -40,6 +40,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
+ extern const FFCodecParser ff_aac_parser;
+ extern const FFCodecParser ff_aac_latm_parser;
+ extern const FFCodecParser ff_ac3_parser;
++extern const FFCodecParser ff_ac4_parser;
+ extern const FFCodecParser ff_adx_parser;
+ extern const FFCodecParser ff_ahx_parser;
+ extern const FFCodecParser ff_amr_parser;
 diff --git a/libavformat/mpegts.c b/libavformat/mpegts.c
-index 427bb88a3e..9156e34234 100644
+index 427bb88a3e..d0464eb09c 100644
 --- a/libavformat/mpegts.c
 +++ b/libavformat/mpegts.c
-@@ -879,6 +879,7 @@ static const StreamType HLS_SAMPLE_ENC_types[] = {
- static const StreamType REGD_types[] = {
-     { MKTAG('d', 'r', 'a', 'c'), AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_DIRAC },
-     { MKTAG('A', 'C', '-', '3'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC3   },
-+    { MKTAG('A', 'C', '-', '4'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 },
-     { MKTAG('A', 'C', '-', '4'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4   },
-     { MKTAG('B', 'S', 'S', 'D'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_S302M },
-     { MKTAG('D', 'T', 'S', '1'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_DTS   },
-@@ -2247,6 +2248,11 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type
+@@ -2247,6 +2247,11 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type
          ext_desc_tag = get8(pp, desc_end);
          if (ext_desc_tag < 0)
              return AVERROR_INVALIDDATA;
 +        if (st->codecpar->codec_id == AV_CODEC_ID_BIN_DATA &&
-+            ext_desc_tag == 0x15) {
++            ext_desc_tag == AC4_DESCRIPTOR_TAG_EXTENSION) {
 +            st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
 +            st->codecpar->codec_id = AV_CODEC_ID_AC4;
 +        }
          if (st->codecpar->codec_id == AV_CODEC_ID_OPUS &&
              ext_desc_tag == 0x80) { /* User defined (provisional Opus) */
              if (!st->codecpar->extradata) {
+diff --git a/libavformat/mpegts.h b/libavformat/mpegts.h
+index 18f326b8bf..8fa4385e33 100644
+--- a/libavformat/mpegts.h
++++ b/libavformat/mpegts.h
+@@ -209,6 +209,7 @@ https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/
+ 
+ /* ISO/IEC 13818-1 Table 2-109 */
+ #define JXS_VIDEO_DESCRIPTOR         0x14 /* JPEG-XS descriptor */
++#define AC4_DESCRIPTOR_TAG_EXTENSION 0x15
+ #define LCEVC_VIDEO_DESCRIPTOR       0x17 /* LCEVC video descriptor */
+ #define LCEVC_LINKAGE_DESCRIPTOR     0x18 /* LCEVC linkage descriptor */
+ 
+@@ -228,6 +229,7 @@ https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/
+ /* DVB descriptor_tag_extension values from
+    ETSI EN 300 468 Table 109: Possible locations of extended descriptors */
+ #define SUPPLEMENTARY_AUDIO_DESCRIPTOR 0x06
++#define AC4_DESCRIPTOR 0x15
+ 
+ /** see "Dolby Vision Streams Within the MPEG-2 Transport Stream Format"
+ https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby-vision-bitstreams-in-mpeg-2-transport-stream-multiplex-v1.2.pdf */

--- a/packages/multimedia/ffmpeg/patches/0007-add-ac4-decoder-parser-from-librempeg.patch
+++ b/packages/multimedia/ffmpeg/patches/0007-add-ac4-decoder-parser-from-librempeg.patch
@@ -1,0 +1,8740 @@
+diff --git a/custom-edits.patch b/custom-edits.patch
+new file mode 100644
+index 0000000000..93140f778c
+--- /dev/null
++++ b/custom-edits.patch
+@@ -0,0 +1,30 @@
++diff --git a/libavcodec/ac4dec.c b/libavcodec/ac4dec.c
++index 27b8a037e9..ff2ff4739c 100644
++--- a/libavcodec/ac4dec.c
+++++ b/libavcodec/ac4dec.c
++@@ -32,6 +32,16 @@
++ #include "libavutil/opt.h"
++ 
++ #include "ac4dec_data.h"
+++
+++static void ac4_vector_fmul_reverse_c(float *dst, const float *src0,
+++                                      const float *src1, int len)
+++{
+++    int i;
+++    src1 += len - 1;
+++    for (i = 0; i < len; i++)
+++        dst[i] = src0[i] * src1[-i];
+++}
+++
++ #include "avcodec.h"
++ #include "get_bits.h"
++ #include "codec_internal.h"
++@@ -5390,7 +5400,7 @@ static void spectral_synthesis(AC4DecodeContext *s, SubstreamChannel *ssch)
++                 s->fdsp->vector_fmul_reverse(overlap + nskip_prev,
++                                              overlap + nskip_prev, swinr, N_prev);
++             else
++-                ff_vector_fmul_reverse_c(overlap + nskip_prev,
+++                ac4_vector_fmul_reverse_c(overlap + nskip_prev,
++                                          overlap + nskip_prev, swinr, N_prev);
++ 
++             for (int n = 0; n < N; n++)
+diff --git a/inject-ac4.sh b/inject-ac4.sh
+new file mode 100755
+index 0000000000..b8b5de4b2e
+--- /dev/null
++++ b/inject-ac4.sh
+@@ -0,0 +1,66 @@
++#!/bin/bash
++set -e
++
++echo "Downloading AC-4 DSP files from librempeg..."
++curl -sL https://raw.githubusercontent.com/librempeg/librempeg/master/libavcodec/ac4dec.c > libavcodec/ac4dec.c
++curl -sL https://raw.githubusercontent.com/librempeg/librempeg/master/libavcodec/ac4dec_data.h > libavcodec/ac4dec_data.h
++curl -sL https://raw.githubusercontent.com/librempeg/librempeg/master/libavcodec/ac4_parser.c > libavcodec/ac4_parser.c
++
++echo "Applying custom DSP edits..."
++git apply custom-edits.patch
++
++echo "Applying FFmpeg static glue..."
++
++# libavcodec/Makefile
++if ! grep -q "ac4dec.o" libavcodec/Makefile; then
++    sed -i '/OBJS-$(CONFIG_AC3_DECODER)/a OBJS-$(CONFIG_AC4_DECODER)             += ac4dec.o' libavcodec/Makefile
++fi
++if ! grep -q "ac4_parser.o" libavcodec/Makefile; then
++    sed -i '/OBJS-$(CONFIG_AC3_PARSER)/a OBJS-$(CONFIG_AC4_PARSER)              += ac4_parser.o' libavcodec/Makefile
++fi
++
++# libavcodec/allcodecs.c
++if ! grep -q "&ff_ac4_decoder" libavcodec/allcodecs.c; then
++    sed -i '/&ff_ac3_decoder/a \    extern const FFCodec ff_ac4_decoder;' libavcodec/allcodecs.c
++fi
++
++# libavcodec/kbdwin.h
++if ! grep -q "av_cold void ff_kbd_window_init" libavcodec/kbdwin.h; then
++    sed -i 's/void ff_kbd_window_init/av_cold void ff_kbd_window_init/' libavcodec/kbdwin.h
++fi
++
++# libavcodec/parsers.c
++if ! grep -q "&ff_ac4_parser" libavcodec/parsers.c; then
++    sed -i '/&ff_ac3_parser/a \    extern const AVCodecParser ff_ac4_parser;' libavcodec/parsers.c
++fi
++
++# libavformat/mpegts.c
++if ! grep -q "AV_CODEC_ID_AC4.*ATSC 3.0" libavformat/mpegts.c; then
++    sed -i '/{ 0xac, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC3 }/a \    { 0xae, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 }, /* ATSC 3.0 */' libavformat/mpegts.c
++fi
++if ! grep -q "ac-4.*AVMEDIA_TYPE_AUDIO" libavformat/mpegts.c; then
++    sed -i '/MKTAG('\''a'\'', '\''c'\'', '\''-'\'', '\''3'\'')/a \    { MKTAG('\''a'\'', '\''c'\'', '\''-'\'', '\''4'\''), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 },' libavformat/mpegts.c
++    sed -i '/MKTAG('\''A'\'', '\''C'\'', '\''-'\'', '\''3'\'')/a \    { MKTAG('\''A'\'', '\''C'\'', '\''-'\'', '\''4'\''), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 },' libavformat/mpegts.c
++fi
++
++# DVB Extension Descriptor parsing for ATSC 3.0 AC-4 streams
++if ! grep -q "ext_desc_tag == 0x15.*AV_CODEC_ID_AC4" libavformat/mpegts.c; then
++    sed -i '/if (ext_desc_tag < 0)/{
++n
++a\
++        if (st->codecpar->codec_id == AV_CODEC_ID_BIN_DATA &&\
++            ext_desc_tag == 0x15) {\
++            st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;\
++            st->codecpar->codec_id = AV_CODEC_ID_AC4;\
++        }
++    }' libavformat/mpegts.c
++fi
++
++echo "Staging files..."
++git add libavcodec/ac4dec.c libavcodec/ac4dec_data.h libavcodec/ac4_parser.c
++git add libavcodec/Makefile libavcodec/allcodecs.c libavcodec/kbdwin.h libavcodec/parsers.c libavformat/mpegts.c
++
++if ! git diff --cached --quiet; then
++    git commit -m "ffmpeg: Inject AC-4 decoder from librempeg"
++fi
++echo "AC-4 injection complete."
+diff --git a/libavcodec/Makefile b/libavcodec/Makefile
+index 1410bd8142..9deea30d14 100644
+--- a/libavcodec/Makefile
++++ b/libavcodec/Makefile
+@@ -212,6 +212,7 @@ OBJS-$(CONFIG_AAC_MEDIACODEC_DECODER)  += mediacodecdec.o
+ OBJS-$(CONFIG_AAC_MF_ENCODER)          += mfenc.o mf_utils.o
+ OBJS-$(CONFIG_AASC_DECODER)            += aasc.o msrledec.o
+ OBJS-$(CONFIG_AC3_DECODER)             += ac3dec_float.o ac3dec_data.o ac3.o \
++OBJS-$(CONFIG_AC4_DECODER)             += ac4dec.o
+                                           kbdwin.o ac3tab.o ac3_channel_layout_tab.o
+ OBJS-$(CONFIG_AC3_FIXED_DECODER)       += ac3dec_fixed.o ac3dec_data.o ac3.o \
+                                           kbdwin.o ac3tab.o ac3_channel_layout_tab.o
+@@ -1238,6 +1239,7 @@ OBJS-$(CONFIG_LIBZVBI_TELETEXT_DECODER)   += libzvbi-teletextdec.o ass.o
+ OBJS-$(CONFIG_AAC_LATM_PARSER)         += latm_parser.o
+ OBJS-$(CONFIG_AAC_PARSER)              += aac_parser.o aac_ac3_parser.o
+ OBJS-$(CONFIG_AC3_PARSER)              += aac_ac3_parser.o ac3tab.o \
++OBJS-$(CONFIG_AC4_PARSER)              += ac4_parser.o
+                                           ac3_channel_layout_tab.o
+ OBJS-$(CONFIG_ADX_PARSER)              += adx_parser.o
+ OBJS-$(CONFIG_AHX_PARSER)              += ahx_parser.o
+diff --git a/libavcodec/ac4_parser.c b/libavcodec/ac4_parser.c
+new file mode 100644
+index 0000000000..1ad425f0cf
+--- /dev/null
++++ b/libavcodec/ac4_parser.c
+@@ -0,0 +1,97 @@
++/*
++ * Copyright (c) 2025 Paul B Mahol
++ *
++ * This file is part of Librempeg
++ *
++ * Librempeg is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * Librempeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along
++ * with Librempeg; if not, write to the Free Software Foundation, Inc.,
++ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++
++/**
++ * @file
++ * AC-4 audio parser
++ *
++ * Determines the duration for each packet.
++ */
++
++#include "libavutil/mem_internal.h"
++#include "libavutil/rational.h"
++#include "ac4dec_data.h"
++#include "get_bits.h"
++#include "parser.h"
++#include "parser_internal.h"
++
++static int variable_bits(GetBitContext *gb, int bits)
++{
++    int value = 0;
++    int read_more;
++
++    do {
++        value += get_bits(gb, bits);
++        read_more = get_bits1(gb);
++        if (read_more) {
++            value <<= bits;
++            value += 1 << bits;
++        }
++    } while (read_more);
++
++    return value;
++}
++
++static int ac4_parse(AVCodecParserContext *s1, AVCodecContext *avctx,
++                     const uint8_t **poutbuf, int *poutbuf_size,
++                     const uint8_t *buf, int buf_size)
++{
++    int version, frame_rate_index, ret, fs_index;
++    AVRational resampling_ratio;
++    GetBitContext gbc, *gb = &gbc;
++
++    ret = init_get_bits8(gb, buf, buf_size);
++    if (ret < 0)
++        return ret;
++
++    version = get_bits(gb, 2);
++    if (version == 3)
++        version += variable_bits(gb, 2);
++    get_bits(gb, 10);
++
++    if (get_bits1(gb)) {
++        int nb_wait_frames = get_bits(gb, 3);
++
++        if (nb_wait_frames > 0)
++            skip_bits(gb, 2);
++    }
++
++    fs_index = get_bits1(gb);
++    frame_rate_index = get_bits(gb, 4);
++    resampling_ratio = resampling_ratios[frame_rate_index];
++    s1->key_frame = get_bits1(gb);
++
++    s1->duration = frame_len_base_48khz[frame_rate_index];
++    avctx->sample_rate = fs_index ? 48000 : 44100;
++    avctx->sample_rate = av_rescale(avctx->sample_rate,
++                                    resampling_ratio.den,
++                                    resampling_ratio.num);
++
++    /* always return the full packet. this parser isn't doing any splitting or
++       combining, only packet analysis */
++    *poutbuf      = buf;
++    *poutbuf_size = buf_size;
++    return buf_size;
++}
++
++const FFCodecParser ff_ac4_parser = {
++    PARSER_CODEC_LIST(AV_CODEC_ID_AC4),
++    .parse = ac4_parse,
++};
+diff --git a/libavcodec/ac4dec.c b/libavcodec/ac4dec.c
+new file mode 100644
+index 0000000000..ff2ff4739c
+--- /dev/null
++++ b/libavcodec/ac4dec.c
+@@ -0,0 +1,6771 @@
++/*
++ * AC-4 Audio Decoder
++ *
++ * Copyright (c) 2019 Paul B Mahol
++ *
++ * This file is part of Librempeg
++ *
++ * Librempeg is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * Librempeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along
++ * with Librempeg; if not, write to the Free Software Foundation, Inc.,
++ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++
++#define ASSERT_LEVEL 2
++#include "libavutil/avassert.h"
++#include "libavutil/tx.h"
++#include "libavutil/channel_layout.h"
++#include "libavutil/float_dsp.h"
++#include "libavutil/mem_internal.h"
++#include "libavutil/mem.h"
++#include "libavutil/thread.h"
++#include "libavutil/qsort.h"
++#include "libavutil/opt.h"
++
++#include "ac4dec_data.h"
++
++static void ac4_vector_fmul_reverse_c(float *dst, const float *src0,
++                                      const float *src1, int len)
++{
++    int i;
++    src1 += len - 1;
++    for (i = 0; i < len; i++)
++        dst[i] = src0[i] * src1[-i];
++}
++
++#include "avcodec.h"
++#include "get_bits.h"
++#include "codec_internal.h"
++#include "decode.h"
++#include "kbdwin.h"
++#include "unary.h"
++
++#define MAX_QMF_TSLOTS 32
++#define MAX_QMF_BANDS 64
++#define MAX_SBG_NOISE 5
++#define MAX_ATSG_NOISE 2
++#define MAX_ASPX_SIGNAL 5
++
++/* Number of model bits */
++#define SSF_MODEL_BITS 15
++
++/* Model unit for the CDF specification */
++#define SSF_MODEL_UNIT (1U<<(SSF_MODEL_BITS))
++
++/* Number of range bits */
++#define SSF_RANGE_BITS    30
++
++/* Half of the range unit */
++#define SSF_THRESHOLD_LARGE (1U<<((SSF_RANGE_BITS)-1))
++
++/* Quarter of the range unit */
++#define SSF_THRESHOLD_SMALL    (1U<<((SSF_RANGE_BITS)-2))
++
++/* Offset bits */
++#define SSF_OFFSET_BITS 14
++
++typedef struct ACState {
++    uint32_t ui_low;
++    uint32_t ui_range;
++    uint32_t ui_offset;
++    uint32_t ui_offset2;
++
++    uint32_t ui_threshold_small;
++    uint32_t ui_threshold_large;
++    uint32_t ui_model_unit;
++
++    uint32_t ui_range_bits;
++    uint32_t ui_model_bits;
++} ACState;
++
++typedef struct EMDFInfo {
++    int     version;
++    int     key_id;
++    int     substream_index;
++} EMDFInfo;
++
++typedef struct SubstreamChannelParameters {
++    uint8_t long_frame;
++    uint8_t transf_length_idx[2];
++    int     transf_length[2];
++
++    uint8_t different_framing;
++    uint8_t max_sfb_side[2];
++    uint8_t max_sfb[2];
++    uint8_t scale_factor_grouping[18];
++
++    uint8_t num_windows;
++    uint8_t num_window_groups;
++    uint8_t window_to_group[16];
++    uint8_t num_win_in_group[16];
++
++    uint8_t dual_maxsfb;
++    uint8_t side_limited;
++    uint8_t side_channel;
++} SubstreamChannelParameters;
++
++typedef struct SubstreamChannel {
++    SubstreamChannelParameters scp;
++
++    int     master_reset;
++    int     num_sbg_master;
++    int     num_sb_aspx;
++    int     num_sbg_noise;
++    int     num_sbg_sig_highres;
++    int     num_sbg_sig_lowres;
++    int     sba;
++    int     sbx;
++    int     sbz;
++
++    int     sap_mode;
++    int     N_prev;
++    int     idx_prev;
++
++    uint8_t ms_used[16][128];
++    uint8_t sap_coeff_used[16][128];
++    uint8_t dpcm_alpha_q[16][128];
++
++    int     delta_code_time;
++
++    int     num_sec_lsf[16];
++    int     num_sec[16];
++    uint8_t sfb_cb[16][128];
++    uint8_t sect_cb[16][128];
++    int     sect_start[16][128];
++    int     sect_end[16][128];
++    int     sect_sfb_offset[16][128];
++
++    int16_t quant_spec[8192];
++    int16_t offset2sfb[8192];
++    uint8_t offset2g[8192];
++    int     win_offset[16];
++
++    int     max_quant_idx[16][128];
++    int     dpcm_sf[16][128];
++    int     dpcm_snf[16][128];
++    int     snf_data_exists;
++
++    float   sf_gain[16][128];
++
++    int     aspx_int_class;
++    int     aspx_num_noise;
++    int     aspx_num_rel_left;
++    int     aspx_num_rel_right;
++    int     aspx_num_env;
++    int     num_atsg_sig;
++    int     num_atsg_sig_prev;
++    int     num_atsg_noise;
++    int     num_atsg_noise_prev;
++    uint8_t aspx_freq_res[MAX_ASPX_SIGNAL+1];
++    int     aspx_var_bord_left;
++    int     aspx_var_bord_right;
++    int     aspx_rel_bord_left[4];
++    int     aspx_rel_bord_right[4];
++    int     aspx_tsg_ptr;
++    int     aspx_tsg_ptr_prev;
++
++    int     aspx_qmode_env;
++    uint8_t aspx_sig_delta_dir[MAX_ASPX_SIGNAL];
++    uint8_t aspx_noise_delta_dir[2];
++    uint8_t aspx_tna_mode[MAX_SBG_NOISE];
++    uint8_t aspx_tna_mode_prev[MAX_SBG_NOISE];
++    uint8_t aspx_add_harmonic[MAX_QMF_TSLOTS];
++    uint8_t aspx_fic_used_in_sfb[MAX_QMF_TSLOTS];
++    uint8_t aspx_tic_used_in_slot[MAX_QMF_TSLOTS];
++    int     aspx_xover_subband_offset;
++    int     aspx_balance;
++
++    uint8_t atsg_freqres[MAX_ASPX_SIGNAL];
++    uint8_t atsg_sig[MAX_ASPX_SIGNAL+1];
++    uint8_t atsg_noise[MAX_ASPX_SIGNAL];
++    int     previous_stop_pos;
++
++    int     sbg_noise[MAX_SBG_NOISE];
++    int     sbg_sig_lowres[24];
++    int     sbg_sig_highres[24];
++    int     sbg_lim[32];
++    int     sbg_patches[MAX_SBG_NOISE];
++    int     sbg_patch_num_sb[MAX_SBG_NOISE];
++    int     sbg_patch_start_sb[MAX_SBG_NOISE];
++    int     sbg_master[24];
++
++    int     num_sbg_sig[6];
++    int     sbg_sig[6][24];
++    int     num_sbg_patches;
++    int     num_sbg_lim;
++
++    int16_t aspx_data[2][MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++
++    int8_t  qscf_prev[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    int8_t  qscf_noise_prev[MAX_ATSG_NOISE][MAX_SBG_NOISE];
++    int8_t  qscf_sig_sbg[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    int8_t  qscf_sig_sbg_prev[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   scf_sig_sbg[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   scf_sig_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    int8_t  qscf_noise_sbg[MAX_ATSG_NOISE][MAX_SBG_NOISE];
++    float   scf_noise_sbg[MAX_ATSG_NOISE][MAX_SBG_NOISE];
++    float   scf_noise_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++
++    float   gain_vec[MAX_QMF_BANDS];
++    float   chirp_arr[MAX_SBG_NOISE];
++    float   chirp_arr_prev[MAX_SBG_NOISE];
++    float   est_sig_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    uint8_t sine_idx_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    uint8_t sine_idx_sb_prev[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    uint8_t sine_area_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   sine_lev_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   noise_lev_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   sig_gain_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   max_sig_gain_sbg[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   max_sig_gain_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   noise_lev_sb_lim[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   sig_gain_sb_lim[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   boost_fact_sbg[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   boost_fact_sb[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   sig_gain_sb_adj[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   noise_lev_sb_adj[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++    float   sine_lev_sb_adj[MAX_ASPX_SIGNAL][MAX_QMF_BANDS];
++
++    int8_t  sine_idx_prev[MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++    int16_t noise_idx_prev[MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++
++    int     acpl_interpolation_type;
++    int     acpl_num_param_sets_cod;
++    int     acpl_param_timeslot[2];
++    int     acpl_data[11][16];
++
++    int     start_block, end_block;
++    int     stride_flag;
++    int     num_bands;
++    int     predictor_presence[4];
++    int     predictor_lag_delta[4];
++    int     predictor_lag[4];
++    int     variance_preserving[4];
++    int     alloc_offset[4];
++    int     delta[4];
++    int     gain_bits[4];
++    int     env_idx[19];
++    ACState acs;
++
++    DECLARE_ALIGNED(32, float, scaled_spec)[2048];
++    DECLARE_ALIGNED(32, float, spec_reord)[2048];
++
++    DECLARE_ALIGNED(32, float, pcm)[2048];
++    DECLARE_ALIGNED(32, float, imdct_out)[4096];
++    DECLARE_ALIGNED(32, float, overlap)[4096];
++
++    DECLARE_ALIGNED(32, float, qana_filt)[MAX_QMF_BANDS*10];
++    DECLARE_ALIGNED(32, float, qmf_sine)[2][MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, qmf_noise)[2][MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, qsyn_filt)[MAX_QMF_BANDS*20];
++    DECLARE_ALIGNED(32, float, L)[MAX_QMF_TSLOTS];
++    DECLARE_ALIGNED(32, float, g)[MAX_QMF_TSLOTS];
++    DECLARE_ALIGNED(32, float, E)[MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, Q)[2][MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, Q_prev)[2][MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, Q_low)[2][MAX_QMF_TSLOTS+6][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, Q_low_prev)[2][MAX_QMF_TSLOTS+6][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, Q_low_ext)[2][MAX_QMF_TSLOTS+10][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, Q_high)[2][MAX_QMF_TSLOTS+4][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, cov)[MAX_QMF_BANDS][3][3][2];
++    DECLARE_ALIGNED(32, float, alpha0)[MAX_QMF_BANDS][2];
++    DECLARE_ALIGNED(32, float, alpha1)[MAX_QMF_BANDS][2];
++    DECLARE_ALIGNED(32, float, Y)[2][MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, Y_prev)[2][MAX_QMF_TSLOTS][MAX_QMF_BANDS];
++} SubstreamChannel;
++
++typedef struct Substream {
++    int     codec_mode;
++    int     im_codec_mode;
++    int     core_5ch_grouping;
++    int     use_sap_add_ch;
++
++    int     aspx_quant_mode_env;
++    int     aspx_start_freq;
++    int     prev_aspx_start_freq;
++    int     aspx_stop_freq;
++    int     prev_aspx_stop_freq;
++    int     aspx_master_freq_scale;
++    int     prev_aspx_master_freq_scale;
++    int     aspx_interpolation;
++    int     aspx_preflat;
++    int     aspx_limiter;
++    int     aspx_noise_sbg;
++    int     aspx_num_env_bits_fixfix;
++    int     aspx_freq_res_mode;
++
++    int     acpl_qmf_band;
++    int     acpl_param_band;
++    int     acpl_num_param_bands_id;
++    uint8_t acpl_quant_mode[2];
++
++    uint8_t sync_flag;
++    uint8_t mode_2ch;
++    uint8_t chel_matsel;
++
++    uint8_t compand_on[12];
++    uint8_t compand_avg;
++
++    int     max_sfb_master;
++
++    uint8_t coding_config;
++    uint8_t mdct_stereo_proc[8];
++    float   matrix_stereo[16][128][2][2];
++    int8_t  alpha_q[16][128];
++
++    int     spec_frontend_l;
++    int     spec_frontend_r;
++    int     spec_frontend_m;
++    int     spec_frontend_s;
++
++    DECLARE_ALIGNED(32, float, g_sum)[MAX_QMF_TSLOTS];
++
++    SubstreamChannel ssch[12];
++} Substream;
++
++typedef struct PresentationSubstreamInfo {
++    int     alternative;
++    int     pres_ndot;
++    int     substream_index;
++} PresentationSubstreamInfo;
++
++typedef struct Metadata {
++    int     dialnorm_bits;
++    int     pre_dmixtyp_2ch;
++    int     phase90_info_2ch;
++    int     loro_center_mixgain;
++    int     loro_surround_mixgain;
++    int     loro_dmx_loud_corr;
++    int     ltrt_center_mixgain;
++    int     ltrt_surround_mixgain;
++    int     ltrt_dmx_loud_corr;
++    int     lfe_mixgain;
++    int     preferred_dmx_method;
++    int     pre_dmixtyp_5ch;
++    int     pre_upmixtyp_5ch;
++    int     pre_upmixtyp_3_4;
++    int     pre_upmixtyp_3_2_2;
++    int     phase90_info_mc;
++    int     surround_attenuation_known;
++    int     lfe_attenuation_known;
++    int     dc_block_on;
++
++    int     loudness_version;
++    int     loud_prac_type;
++    int     dialgate_prac_type;
++    int     loudcorr_type;
++    int     loudrelgat;
++    int     loudspchgat;
++    int     loudstrm3s;
++    int     max_loudstrm3s;
++    int     truepk;
++    int     max_truepk;
++    int     prgmbndy;
++    int     end_or_start;
++    int     prgmbndy_offset;
++    int     lra;
++    int     lra_prac_type;
++    int     loudmntry;
++    int     max_loudmntry;
++
++    int     drc_decoder_nr_modes;
++    int     drc_eac3_profile;
++} Metadata;
++
++typedef struct SubstreamInfo {
++    int     sus_ver;
++    int     channel_mode;
++    int     substream_index;
++    int     hsf_ext_substream_index;
++    int     sf_multiplier;
++    int     bitrate_indicator;
++    int     add_ch_base;
++    int     iframe[4];
++    int     back_channels_present;
++    int     centre_present;
++    int     top_channels_present;
++
++    int lfe;
++    int static_dmx;
++    int audio_ndot[4];
++    int n_fullband_dmx_signals;
++    int n_fullband_upmix_signals;
++
++    int n_objects;
++
++    Metadata meta;
++} SubstreamInfo;
++
++typedef struct SubstreamGroupInfo {
++    int           channel_coded;
++    int           ajoc;
++    int           group_index;
++    SubstreamInfo ssinfo;
++} SubstreamGroupInfo;
++
++typedef struct PresentationInfo {
++    int     single_substream;
++    int     enable_presentation;
++    int     presentation_config;
++    int     presentation_version;
++    int     add_emdf_substreams;
++    int     n_add_emdf_substreams;
++    int     n_substream_groups;
++    int     mdcompat;
++    int     presentation_id;
++    int     multiplier;
++    int     multiplier_bit;
++    int     pre_virtualized;
++    int     frame_rate_factor;
++    int     frame_rate_fraction;
++    int     multi_pid;
++    int     hsf_ext;
++    EMDFInfo emdf[32];
++    PresentationSubstreamInfo psinfo;
++    SubstreamInfo ssinfo[4];
++} PresentationInfo;
++
++typedef struct AC4DecodeContext {
++    AVClass        *class;                  ///< class for AVOptions
++    AVCodecContext *avctx;                  ///< parent context
++    AVFloatDSPContext *fdsp;
++    GetBitContext   gbc;                    ///< bitstream reader
++
++    int             target_presentation;
++
++    int             version;
++    int             sequence_counter;
++    int             sequence_counter_prev;
++    int             wait_frames;
++    int             nb_wait_frames;
++    int             fs_index;
++    int             frame_rate_index;
++    int             frame_len_base;
++    int             frame_len_base_idx;
++    AVRational      resampling_ratio;
++    int             num_qmf_timeslots;
++    int             num_aspx_timeslots;
++    int             num_ts_in_ats;
++    int             ts_offset_hfgen;
++    int             transform_length;
++    int             iframe_global;
++    int             first_frame;
++    int             have_iframe;
++    int             nb_presentations;
++    int             payload_base;
++    int             short_program_id;
++    int             nb_substreams;
++    int             total_groups;
++    int             substream_size[32];
++    int             substream_type[32];
++    int             ch_map[256];
++
++    av_tx_fn        tx_fn[8][5];
++    AVTXContext    *tx_ctx[8][5];
++
++    DECLARE_ALIGNED(32, float, kbd_window)[8][5][2048];
++
++    float           quant_lut[8192];
++
++    DECLARE_ALIGNED(32, float, cos_atab)[MAX_QMF_BANDS][MAX_QMF_BANDS*2];
++    DECLARE_ALIGNED(32, float, sin_atab)[MAX_QMF_BANDS][MAX_QMF_BANDS*2];
++    DECLARE_ALIGNED(32, float, cos_stab)[MAX_QMF_BANDS*2][MAX_QMF_BANDS];
++    DECLARE_ALIGNED(32, float, sin_stab)[MAX_QMF_BANDS*2][MAX_QMF_BANDS];
++
++    PresentationInfo   pinfo[16];
++    SubstreamGroupInfo ssgroup[16];
++    Substream          substream;
++} AC4DecodeContext;
++
++enum StrideFlag {
++    LONG_STRIDE,
++    SHORT_STRIDE,
++};
++
++enum ImmersiveMode {
++    IM_SCPL,
++    IM_ASPX_SCPL,
++    IM_ASPX_ACPL_1,
++    IM_ASPX_ACPL_2,
++    IM_ASPX_AJCC,
++};
++
++enum ACPLMode {
++    ACPL_FULL,
++    ACPL_PARTIAL,
++};
++
++enum SubstreamType {
++    ST_SUBSTREAM,
++    ST_PRESENTATION,
++};
++
++enum StereoMode {
++    SM_LEVEL,
++    SM_BALANCE,
++};
++
++enum DataType {
++    DT_SIGNAL,
++    DT_NOISE,
++};
++
++enum SpectralFrontend {
++    SF_ASF,
++    SF_SSF,
++};
++
++enum HCBType {
++    F0,
++    DF,
++    DT,
++};
++
++enum CodecMode {
++    CM_SIMPLE,
++    CM_ASPX,
++    CM_ASPX_ACPL_1,
++    CM_ASPX_ACPL_2,
++    CM_ASPX_ACPL_3,
++};
++
++enum IntervalClass {
++    FIXFIX,
++    FIXVAR,
++    VARFIX,
++    VARVAR,
++};
++
++enum ACPLDataType {
++    ALPHA1,
++    ALPHA2,
++    BETA1,
++    BETA2,
++    BETA3,
++    GAMMA1,
++    GAMMA2,
++    GAMMA3,
++    GAMMA4,
++    GAMMA5,
++    GAMMA6,
++};
++
++static const uint16_t decode_delays[] = {
++    288,
++    288,
++    352,
++    96,
++    96,
++    960,
++    960,
++    1056,
++    672,
++    672,
++    1312,
++    864,
++    864,
++    352,
++    352,
++};
++
++static const AVChannelLayout channel_mode_layouts[] = {
++    AV_CHANNEL_LAYOUT_MONO,
++    AV_CHANNEL_LAYOUT_STEREO,
++    AV_CHANNEL_LAYOUT_SURROUND,
++    AV_CHANNEL_LAYOUT_5POINT0,
++    AV_CHANNEL_LAYOUT_5POINT1,
++    AV_CHANNEL_LAYOUT_7POINT0,
++    AV_CHANNEL_LAYOUT_7POINT1,
++    AV_CHANNEL_LAYOUT_7POINT0_FRONT,
++    {
++        .nb_channels = 7,
++        .order = AV_CHANNEL_ORDER_NATIVE,
++        .u.mask = AV_CH_LAYOUT_7POINT0 | AV_CH_LOW_FREQUENCY,
++    },
++    { 0 },
++    { 0 },
++    { 0 },
++    {
++        .nb_channels = 12,
++        .order = AV_CHANNEL_ORDER_NATIVE,
++        .u.mask = AV_CH_LAYOUT_7POINT0 | AV_CH_LOW_FREQUENCY |
++                  AV_CH_TOP_FRONT_LEFT | AV_CH_TOP_FRONT_RIGHT |
++                  AV_CH_TOP_BACK_LEFT | AV_CH_TOP_BACK_RIGHT,
++    },
++    { 0 },
++    { 0 },
++    { 0 },
++    { 0 },
++    { 0 },
++};
++
++static VLC channel_mode_vlc;
++static VLC bitrate_indicator_vlc;
++static VLC scale_factors_vlc;
++static VLC snf_vlc;
++static VLC asf_codebook_vlc[11];
++static VLC acpl_codebook_vlc[4][2][3];
++static VLC aspx_int_class_vlc;
++static VLC aspx_codebook_signal_vlc[2][2][3];
++static VLC aspx_codebook_noise_vlc[2][3];
++
++static av_cold void ac4_init_static(void)
++{
++    vlc_init(&channel_mode_vlc, 9, sizeof(channel_mode_bits),
++             channel_mode_bits, 1, 1, channel_mode_codes, 2, 2, 0);
++    vlc_init(&bitrate_indicator_vlc, 5, sizeof(bitrate_indicator_bits),
++             bitrate_indicator_bits, 1, 1, bitrate_indicator_codes, 1, 1, 0);
++    vlc_init(&scale_factors_vlc, 9, sizeof(scale_factors_bits),
++             scale_factors_bits, 1, 1, scale_factors_codes, 1, 1, 0);
++    vlc_init(&snf_vlc, 7, sizeof(snf_bits),
++             snf_bits, 1, 1, snf_codes, 1, 1, 0);
++
++    vlc_init(&asf_codebook_vlc[0], 9, sizeof(asf_codebook_1_bits),
++             asf_codebook_1_bits, 1, 1, asf_codebook_1_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[1], 9, sizeof(asf_codebook_2_bits),
++             asf_codebook_2_bits, 1, 1, asf_codebook_2_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[2], 9, sizeof(asf_codebook_3_bits),
++             asf_codebook_3_bits, 1, 1, asf_codebook_3_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[3], 9, sizeof(asf_codebook_4_bits),
++             asf_codebook_4_bits, 1, 1, asf_codebook_4_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[4], 9, sizeof(asf_codebook_5_bits),
++             asf_codebook_5_bits, 1, 1, asf_codebook_5_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[5], 9, sizeof(asf_codebook_6_bits),
++             asf_codebook_6_bits, 1, 1, asf_codebook_6_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[6], 9, sizeof(asf_codebook_7_bits),
++             asf_codebook_7_bits, 1, 1, asf_codebook_7_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[7], 9, sizeof(asf_codebook_8_bits),
++             asf_codebook_8_bits, 1, 1, asf_codebook_8_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[8], 9, sizeof(asf_codebook_9_bits),
++             asf_codebook_9_bits, 1, 1, asf_codebook_9_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[9], 9, sizeof(asf_codebook_10_bits),
++             asf_codebook_10_bits, 1, 1, asf_codebook_10_codes, 1, 1, 0);
++    vlc_init(&asf_codebook_vlc[10], 9, sizeof(asf_codebook_11_bits),
++             asf_codebook_11_bits, 1, 1, asf_codebook_11_codes, 1, 1, 0);
++
++    vlc_init(&aspx_int_class_vlc, 5, sizeof(aspx_int_class_bits),
++             aspx_int_class_bits, 1, 1, aspx_int_class_codes, 1, 1, 0);
++
++    vlc_init(&aspx_codebook_signal_vlc[0][0][0], 9, sizeof(aspx_hcb_env_level_15_f0_bits),
++             aspx_hcb_env_level_15_f0_bits, 1, 1, aspx_hcb_env_level_15_f0_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_signal_vlc[0][0][1], 9, sizeof(aspx_hcb_env_level_15_df_bits),
++             aspx_hcb_env_level_15_df_bits, 1, 1, aspx_hcb_env_level_15_df_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_signal_vlc[0][0][2], 9, sizeof(aspx_hcb_env_level_15_dt_bits),
++             aspx_hcb_env_level_15_dt_bits, 1, 1, aspx_hcb_env_level_15_dt_codes, 4, 4, 0);
++
++    vlc_init(&aspx_codebook_signal_vlc[0][1][0], 9, sizeof(aspx_hcb_env_level_30_f0_bits),
++             aspx_hcb_env_level_30_f0_bits, 1, 1, aspx_hcb_env_level_30_f0_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_signal_vlc[0][1][1], 9, sizeof(aspx_hcb_env_level_30_df_bits),
++             aspx_hcb_env_level_30_df_bits, 1, 1, aspx_hcb_env_level_30_df_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_signal_vlc[0][1][2], 9, sizeof(aspx_hcb_env_level_30_dt_bits),
++             aspx_hcb_env_level_30_dt_bits, 1, 1, aspx_hcb_env_level_30_dt_codes, 4, 4, 0);
++
++    vlc_init(&aspx_codebook_signal_vlc[1][0][0], 9, sizeof(aspx_hcb_env_balance_15_f0_bits),
++             aspx_hcb_env_balance_15_f0_bits, 1, 1, aspx_hcb_env_balance_15_f0_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_signal_vlc[1][0][1], 9, sizeof(aspx_hcb_env_balance_15_df_bits),
++             aspx_hcb_env_balance_15_df_bits, 1, 1, aspx_hcb_env_balance_15_df_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_signal_vlc[1][0][2], 9, sizeof(aspx_hcb_env_balance_15_dt_bits),
++             aspx_hcb_env_balance_15_dt_bits, 1, 1, aspx_hcb_env_balance_15_dt_codes, 4, 4, 0);
++
++    vlc_init(&aspx_codebook_signal_vlc[1][1][0], 9, sizeof(aspx_hcb_env_balance_30_f0_bits),
++             aspx_hcb_env_balance_30_f0_bits, 1, 1, aspx_hcb_env_balance_30_f0_codes, 2, 2, 0);
++    vlc_init(&aspx_codebook_signal_vlc[1][1][1], 9, sizeof(aspx_hcb_env_balance_30_df_bits),
++             aspx_hcb_env_balance_30_df_bits, 1, 1, aspx_hcb_env_balance_30_df_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_signal_vlc[1][1][2], 9, sizeof(aspx_hcb_env_balance_30_dt_bits),
++             aspx_hcb_env_balance_30_dt_bits, 1, 1, aspx_hcb_env_balance_30_dt_codes, 2, 2, 0);
++
++    vlc_init(&aspx_codebook_noise_vlc[0][0], 9, sizeof(aspx_hcb_noise_level_f0_bits),
++             aspx_hcb_noise_level_f0_bits, 1, 1, aspx_hcb_noise_level_f0_codes, 2, 2, 0);
++    vlc_init(&aspx_codebook_noise_vlc[0][1], 9, sizeof(aspx_hcb_noise_level_df_bits),
++             aspx_hcb_noise_level_df_bits, 1, 1, aspx_hcb_noise_level_df_codes, 4, 4, 0);
++    vlc_init(&aspx_codebook_noise_vlc[0][2], 9, sizeof(aspx_hcb_noise_level_dt_bits),
++             aspx_hcb_noise_level_dt_bits, 1, 1, aspx_hcb_noise_level_dt_codes, 2, 2, 0);
++
++    vlc_init(&aspx_codebook_noise_vlc[1][0], 9, sizeof(aspx_hcb_noise_balance_f0_bits),
++             aspx_hcb_noise_balance_f0_bits, 1, 1, aspx_hcb_noise_balance_f0_codes, 2, 2, 0);
++    vlc_init(&aspx_codebook_noise_vlc[1][1], 9, sizeof(aspx_hcb_noise_balance_df_bits),
++             aspx_hcb_noise_balance_df_bits, 1, 1, aspx_hcb_noise_balance_df_codes, 2, 2, 0);
++    vlc_init(&aspx_codebook_noise_vlc[1][2], 9, sizeof(aspx_hcb_noise_balance_dt_bits),
++             aspx_hcb_noise_balance_dt_bits, 1, 1, aspx_hcb_noise_balance_dt_codes, 2, 2, 0);
++
++    vlc_init(&acpl_codebook_vlc[0][1][0], 9, sizeof(acpl_hcb_alpha_coarse_f0_bits),
++             acpl_hcb_alpha_coarse_f0_bits, 1, 1, acpl_hcb_alpha_coarse_f0_codes, 2, 2, 0);
++    vlc_init(&acpl_codebook_vlc[0][1][1], 9, sizeof(acpl_hcb_alpha_coarse_df_bits),
++             acpl_hcb_alpha_coarse_df_bits, 1, 1, acpl_hcb_alpha_coarse_df_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[0][1][2], 9, sizeof(acpl_hcb_alpha_coarse_dt_bits),
++             acpl_hcb_alpha_coarse_dt_bits, 1, 1, acpl_hcb_alpha_coarse_dt_codes, 4, 4, 0);
++
++    vlc_init(&acpl_codebook_vlc[0][0][0], 9, sizeof(acpl_hcb_alpha_fine_f0_bits),
++             acpl_hcb_alpha_fine_f0_bits, 1, 1, acpl_hcb_alpha_fine_f0_codes, 2, 2, 0);
++    vlc_init(&acpl_codebook_vlc[0][0][1], 9, sizeof(acpl_hcb_alpha_fine_df_bits),
++             acpl_hcb_alpha_fine_df_bits, 1, 1, acpl_hcb_alpha_fine_df_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[0][0][2], 9, sizeof(acpl_hcb_alpha_fine_dt_bits),
++             acpl_hcb_alpha_fine_dt_bits, 1, 1, acpl_hcb_alpha_fine_dt_codes, 4, 4, 0);
++
++    vlc_init(&acpl_codebook_vlc[1][1][0], 9, sizeof(acpl_hcb_beta_coarse_f0_bits),
++             acpl_hcb_beta_coarse_f0_bits, 1, 1, acpl_hcb_beta_coarse_f0_codes, 1, 1, 0);
++    vlc_init(&acpl_codebook_vlc[1][1][1], 9, sizeof(acpl_hcb_beta_coarse_df_bits),
++             acpl_hcb_beta_coarse_df_bits, 1, 1, acpl_hcb_beta_coarse_df_codes, 1, 1, 0);
++    vlc_init(&acpl_codebook_vlc[1][1][2], 9, sizeof(acpl_hcb_beta_coarse_dt_bits),
++             acpl_hcb_beta_coarse_dt_bits, 1, 1, acpl_hcb_beta_coarse_dt_codes, 1, 1, 0);
++
++    vlc_init(&acpl_codebook_vlc[1][0][0], 9, sizeof(acpl_hcb_beta_fine_f0_bits),
++             acpl_hcb_beta_fine_f0_bits, 1, 1, acpl_hcb_beta_fine_f0_codes, 1, 1, 0);
++    vlc_init(&acpl_codebook_vlc[1][0][1], 9, sizeof(acpl_hcb_beta_fine_df_bits),
++             acpl_hcb_beta_fine_df_bits, 1, 1, acpl_hcb_beta_fine_df_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[1][0][2], 9, sizeof(acpl_hcb_beta_fine_dt_bits),
++             acpl_hcb_beta_fine_dt_bits, 1, 1, acpl_hcb_beta_fine_dt_codes, 4, 4, 0);
++
++    vlc_init(&acpl_codebook_vlc[2][1][0], 9, sizeof(acpl_hcb_beta3_coarse_f0_bits),
++             acpl_hcb_beta3_coarse_f0_bits, 1, 1, acpl_hcb_beta3_coarse_f0_codes, 1, 1, 0);
++    vlc_init(&acpl_codebook_vlc[2][1][1], 9, sizeof(acpl_hcb_beta3_coarse_df_bits),
++             acpl_hcb_beta3_coarse_df_bits, 1, 1, acpl_hcb_beta3_coarse_df_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[2][1][2], 9, sizeof(acpl_hcb_beta3_coarse_dt_bits),
++             acpl_hcb_beta3_coarse_dt_bits, 1, 1, acpl_hcb_beta3_coarse_dt_codes, 2, 2, 0);
++
++    vlc_init(&acpl_codebook_vlc[2][0][0], 9, sizeof(acpl_hcb_beta3_fine_f0_bits),
++             acpl_hcb_beta3_fine_f0_bits, 1, 1, acpl_hcb_beta3_fine_f0_codes, 1, 1, 0);
++    vlc_init(&acpl_codebook_vlc[2][0][1], 9, sizeof(acpl_hcb_beta3_fine_df_bits),
++             acpl_hcb_beta3_fine_df_bits, 1, 1, acpl_hcb_beta3_fine_df_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[2][0][2], 9, sizeof(acpl_hcb_beta3_fine_dt_bits),
++             acpl_hcb_beta3_fine_dt_bits, 1, 1, acpl_hcb_beta3_fine_dt_codes, 4, 4, 0);
++
++    vlc_init(&acpl_codebook_vlc[3][1][0], 9, sizeof(acpl_hcb_gamma_coarse_f0_bits),
++             acpl_hcb_gamma_coarse_f0_bits, 1, 1, acpl_hcb_gamma_coarse_f0_codes, 2, 2, 0);
++    vlc_init(&acpl_codebook_vlc[3][1][1], 9, sizeof(acpl_hcb_gamma_coarse_df_bits),
++             acpl_hcb_gamma_coarse_df_bits, 1, 1, acpl_hcb_gamma_coarse_df_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[3][1][2], 9, sizeof(acpl_hcb_gamma_coarse_dt_bits),
++             acpl_hcb_gamma_coarse_dt_bits, 1, 1, acpl_hcb_gamma_coarse_dt_codes, 4, 4, 0);
++
++    vlc_init(&acpl_codebook_vlc[3][0][0], 9, sizeof(acpl_hcb_gamma_fine_f0_bits),
++             acpl_hcb_gamma_fine_f0_bits, 1, 1, acpl_hcb_gamma_fine_f0_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[3][0][1], 9, sizeof(acpl_hcb_gamma_fine_df_bits),
++             acpl_hcb_gamma_fine_df_bits, 1, 1, acpl_hcb_gamma_fine_df_codes, 4, 4, 0);
++    vlc_init(&acpl_codebook_vlc[3][0][2], 9, sizeof(acpl_hcb_gamma_fine_dt_bits),
++             acpl_hcb_gamma_fine_dt_bits, 1, 1, acpl_hcb_gamma_fine_dt_codes, 4, 4, 0);
++}
++
++static av_cold int ac4_decode_init(AVCodecContext *avctx)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++    static AVOnce init_static_once = AV_ONCE_INIT;
++    int ret;
++
++    s->avctx = avctx;
++    s->first_frame = 1;
++
++    avctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
++
++    for (int j = 0; j < 8; j++) {
++        const uint16_t *transf_lengths = transf_length_48khz[j];
++
++        for (int i = 0; i < 5; i++) {
++            int N_w = transf_lengths[i];
++            float alpha = kbd_window_alpha[j][i];
++            float scale = -1.f / N_w;
++
++            if ((ret = av_tx_init(&s->tx_ctx[j][i], &s->tx_fn[j][i],
++                                  AV_TX_FLOAT_MDCT, 1, N_w, &scale, AV_TX_FULL_IMDCT)))
++                return ret;
++
++            ff_kbd_window_init(s->kbd_window[j][i], alpha, N_w);
++        }
++    }
++
++    for (int i = 0; i < 8192; i++)
++        s->quant_lut[i] = powf(i, 4.f / 3.f);
++
++    for (int i = 0; i < MAX_QMF_BANDS; i++) {
++        for (int n = 0; n < MAX_QMF_BANDS*2; n++) {
++            s->cos_atab[i][n] = cosf((M_PI/(MAX_QMF_BANDS*2))*(i+0.5)*(2*n-1));
++            s->sin_atab[i][n] = sinf((M_PI/(MAX_QMF_BANDS*2))*(i+0.5)*(2*n-1));
++            s->cos_stab[n][i] = cosf((M_PI/(MAX_QMF_BANDS*2))*(i+0.5)*(2*n-255)) / MAX_QMF_BANDS;
++            s->sin_stab[n][i] = sinf((M_PI/(MAX_QMF_BANDS*2))*(i+0.5)*(2*n-255)) / MAX_QMF_BANDS;
++        }
++    }
++
++    s->fdsp = avpriv_float_dsp_alloc(avctx->flags & AV_CODEC_FLAG_BITEXACT);
++    if (!s->fdsp)
++        return AVERROR(ENOMEM);
++
++    ff_thread_once(&init_static_once, ac4_init_static);
++
++    return 0;
++}
++
++static int variable_bits(GetBitContext *gb, int bits)
++{
++    int value = 0;
++    int read_more;
++
++    do {
++        value += get_bits(gb, bits);
++        read_more = get_bits1(gb);
++        if (read_more) {
++            value <<= bits;
++            value += 1 << bits;
++        }
++    } while (read_more);
++
++    return value;
++}
++
++static int check_sequence(AC4DecodeContext *s)
++{
++    if (s->sequence_counter > 1020) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid sequence counter: %d\n", s->sequence_counter);
++        return AVERROR_INVALIDDATA;
++    }
++
++    if (s->sequence_counter == s->sequence_counter_prev + 1)
++        return 0;
++
++    if (s->sequence_counter != 0 && s->sequence_counter_prev == 0)
++        return 0;
++
++    if (s->sequence_counter == 1 && s->sequence_counter_prev == 1020)
++        return 0;
++
++    if (s->sequence_counter == 0 && s->sequence_counter_prev == 0)
++        return 0;
++
++    av_log(s->avctx, AV_LOG_ERROR, "unexpected sequence counter: %d vs %d\n", s->sequence_counter, s->sequence_counter_prev);
++    return AVERROR_INVALIDDATA;
++}
++
++static int frame_rate_multiply_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++
++    p->multiplier_bit = 0;
++
++    switch (s->frame_rate_index) {
++    case 2:
++    case 3:
++    case 4:
++        p->multiplier = get_bits1(gb);
++        if (p->multiplier)
++            p->multiplier_bit = get_bits1(gb);
++        p->frame_rate_factor = p->multiplier ? (p->multiplier_bit ? 4 : 2) : 1;
++        break;
++    case 0:
++    case 1:
++    case 7:
++    case 8:
++    case 9:
++        p->multiplier = get_bits1(gb);
++        p->frame_rate_factor = p->multiplier ? 2 : 1;
++        break;
++    default:
++        p->frame_rate_factor = 1;
++        break;
++    }
++
++    av_log(s->avctx, AV_LOG_DEBUG, "frame_rate_factor : %d\n", p->frame_rate_factor);
++
++    return 0;
++}
++
++static int emdf_payloads_substream_info(AC4DecodeContext *s, EMDFInfo *e)
++{
++    GetBitContext *gb = &s->gbc;
++
++    e->substream_index = get_bits(gb, 2);
++    if (e->substream_index == 3)
++        e->substream_index += variable_bits(gb, 2);
++
++    return 0;
++}
++
++static int emdf_protection(AC4DecodeContext *s, EMDFInfo *e)
++{
++    GetBitContext *gb = &s->gbc;
++    int first, second, skip = 0;
++
++    first = get_bits(gb, 2);
++    second = get_bits(gb, 2);
++
++    if (first > 0)
++        skip += 1 << (2 * (first - 1));
++    if (second > 0)
++        skip += 1 << (2 * (second - 1));
++
++    skip_bits_long(gb, 8 * skip);
++
++    return 0;
++}
++
++static int emdf_info(AC4DecodeContext *s, EMDFInfo *e)
++{
++    GetBitContext *gb = &s->gbc;
++
++    e->version = get_bits(gb, 2);
++    if (e->version == 3)
++        e->version += variable_bits(gb, 2);
++    e->key_id = get_bits(gb, 3);
++    if (e->key_id == 7)
++        e->key_id += variable_bits(gb, 3);
++
++    if (get_bits1(gb))
++        emdf_payloads_substream_info(s, e);
++
++    emdf_protection(s, e);
++
++    return 0;
++}
++
++static int content_type(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++
++    s->avctx->audio_service_type = get_bits(gb, 3);
++
++    if (get_bits1(gb)) {
++        if (get_bits1(gb)) {
++            skip_bits(gb, 1);
++            skip_bits(gb, 16);
++        } else {
++            int language_tag_bytes = get_bits(gb, 6);
++
++            skip_bits_long(gb, 8 * language_tag_bytes);
++        }
++    }
++
++    return 0;
++}
++
++static int ac4_hsf_ext_substream_info(AC4DecodeContext *s, SubstreamInfo *ssi,
++                                      int substream_present)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (substream_present) {
++        ssi->hsf_ext_substream_index = get_bits(gb, 2);
++        if (ssi->hsf_ext_substream_index == 3)
++            ssi->hsf_ext_substream_index += variable_bits(gb, 2);
++    }
++
++    return 0;
++}
++
++static int ac4_substream_info(AC4DecodeContext *s, PresentationInfo *p,
++                              SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssi->sus_ver = 0;
++    ssi->channel_mode = get_vlc2(gb, channel_mode_vlc.table, channel_mode_vlc.bits, 3);
++    av_log(s->avctx, AV_LOG_DEBUG, "channel mode: %d\n", ssi->channel_mode);
++    if (ssi->channel_mode < 0) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid channel mode: %d\n", ssi->channel_mode);
++        return AVERROR_INVALIDDATA;
++    }
++
++    if (ssi->channel_mode == 16)
++        ssi->channel_mode += variable_bits(gb, 2);
++
++    if (s->fs_index == 1 && get_bits1(gb))
++        ssi->sf_multiplier = 1 + get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "sf_multiplier: %d\n", ssi->sf_multiplier);
++
++    if (get_bits1(gb))
++        ssi->bitrate_indicator = get_vlc2(gb, bitrate_indicator_vlc.table,
++                                          bitrate_indicator_vlc.bits, 3);
++
++    if (ssi->channel_mode == 7 ||
++        ssi->channel_mode == 8 ||
++        ssi->channel_mode == 9 ||
++        ssi->channel_mode == 10) {
++        ssi->add_ch_base = get_bits1(gb);
++    }
++
++    if (get_bits1(gb))
++        content_type(s, p);
++
++    for (int i = 0; i < p->frame_rate_factor; i++) {
++        ssi->iframe[i] = get_bits1(gb);
++        av_log(s->avctx, AV_LOG_DEBUG, "iframe[%d]: %d\n", i, ssi->iframe[i]);
++    }
++
++    ssi->substream_index = get_bits(gb, 2);
++    if (ssi->substream_index == 3)
++        ssi->substream_index += variable_bits(gb, 2);
++    if (ssi->substream_index >= FF_ARRAY_ELEMS(s->substream_type))
++        return AVERROR_INVALIDDATA;
++    s->substream_type[ssi->substream_index] = ST_SUBSTREAM;
++    av_log(s->avctx, AV_LOG_DEBUG, "substream index: %d\n", ssi->substream_index);
++
++    return 0;
++}
++
++static int presentation_config_ext_info(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int n_skip_bytes;
++
++    n_skip_bytes = get_bits(gb, 5);
++    if (get_bits1(gb))
++        n_skip_bytes += variable_bits(gb, 2) << 5;
++
++    skip_bits_long(gb, 8 * n_skip_bytes);
++
++    return 0;
++}
++
++static int ac4_presentation_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    p->single_substream = get_bits1(gb);
++    if (p->single_substream != 1) {
++        p->presentation_config = get_bits(gb, 3);
++        if (p->presentation_config == 7)
++            p->presentation_config += variable_bits(gb, 2);
++        av_log(s->avctx, AV_LOG_DEBUG, "presentation config: %d\n", p->presentation_config);
++    }
++
++    p->presentation_version = get_unary(gb, 0, 31);
++    av_log(s->avctx, AV_LOG_DEBUG, "presentation version: %d\n", p->presentation_version);
++
++    s->total_groups = 0;
++
++    p->add_emdf_substreams = 0;
++    if (p->single_substream != 1 && p->presentation_config == 6) {
++        p->add_emdf_substreams = 1;
++    } else {
++        p->mdcompat = get_bits(gb, 3);
++
++        if (get_bits1(gb))
++            p->presentation_id = variable_bits(gb, 2);
++
++        frame_rate_multiply_info(s, p);
++        emdf_info(s, &p->emdf[0]);
++
++        if (p->single_substream == 1) {
++            ret = ac4_substream_info(s, p, &p->ssinfo[0]);
++            if (ret < 0)
++                return ret;
++        } else {
++            p->hsf_ext = get_bits1(gb);
++            switch (p->presentation_config) {
++            case 0:
++                ret = ac4_substream_info(s, p, &p->ssinfo[0]);
++                if (ret < 0)
++                    return ret;
++                if (p->hsf_ext) {
++                    ret = ac4_hsf_ext_substream_info(s, &p->ssinfo[0], 1);
++                    if (ret < 0)
++                        return ret;
++                }
++                ret = ac4_substream_info(s, p, &p->ssinfo[1]);
++                if (ret < 0)
++                    return ret;
++                break;
++            case 1:
++            case 2:
++            case 3:
++            case 4:
++            case 5:
++                //FIXME
++                break;
++            default:
++                presentation_config_ext_info(s);
++            }
++        }
++
++        p->pre_virtualized = get_bits1(gb);
++        p->add_emdf_substreams = get_bits1(gb);
++    }
++
++    if (p->add_emdf_substreams) {
++        p->n_add_emdf_substreams = get_bits(gb, 2);
++        if (p->n_add_emdf_substreams == 0)
++            p->n_add_emdf_substreams = variable_bits(gb, 2) + 4;
++        if (p->n_add_emdf_substreams > FF_ARRAY_ELEMS(p->emdf))
++            return AVERROR_INVALIDDATA;
++
++        for (int i = 0; i < p->n_add_emdf_substreams; i++)
++            emdf_info(s, &p->emdf[i]);
++    }
++
++    return 0;
++}
++
++static int substream_index_table(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int size_present;
++
++    s->nb_substreams = get_bits(gb, 2);
++    if (s->nb_substreams == 0)
++        s->nb_substreams = variable_bits(gb, 2) + 4;
++
++    av_log(s->avctx, AV_LOG_DEBUG, "nb_substreams: %d\n", s->nb_substreams);
++
++    if (s->nb_substreams > FF_ARRAY_ELEMS(s->substream_size))
++        return AVERROR_INVALIDDATA;
++
++    if (s->nb_substreams == 1) {
++        size_present = get_bits1(gb);
++    } else {
++        size_present = 1;
++    }
++
++    if (size_present) {
++        for (int i = 0; i < s->nb_substreams; i++) {
++            int more_bits = get_bits1(gb);
++
++            s->substream_size[i] = get_bits(gb, 10);
++            if (more_bits)
++                s->substream_size[i] += variable_bits(gb, 2) << 10;
++            av_log(s->avctx, AV_LOG_DEBUG, "substream[%d] size: %d\n", i, s->substream_size[i]);
++        }
++    }
++
++    return 0;
++}
++
++static int presentation_substream_info(AC4DecodeContext *s, PresentationSubstreamInfo *psi)
++{
++    GetBitContext *gb = &s->gbc;
++
++    psi->alternative = get_bits1(gb);
++    psi->pres_ndot = get_bits1(gb);
++    psi->substream_index = get_bits(gb, 2);
++    if (psi->substream_index == 3)
++        psi->substream_index += variable_bits(gb, 2);
++
++    if (psi->substream_index >= FF_ARRAY_ELEMS(s->substream_type))
++        return AVERROR_INVALIDDATA;
++
++    s->substream_type[psi->substream_index] = ST_PRESENTATION;
++    av_log(s->avctx, AV_LOG_DEBUG, "presentation substream index: %d\n", psi->substream_index);
++
++    return 0;
++}
++
++static int frame_rate_fractions_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++
++    p->frame_rate_fraction = 1;
++    if (s->frame_rate_index >= 5 && s->frame_rate_index <= 9) {
++        if (p->frame_rate_factor == 1) {
++            if (get_bits1(gb))
++                p->frame_rate_fraction = 2;
++        }
++    }
++
++    if (s->frame_rate_index >= 10 && s->frame_rate_index <= 12) {
++        if (get_bits1(gb)) {
++            if (get_bits1(gb))
++                p->frame_rate_fraction = 4;
++            else
++                p->frame_rate_fraction = 2;
++        }
++    }
++
++    return 0;
++}
++
++static int oamd_substream_info(AC4DecodeContext *s, SubstreamGroupInfo *ssi,
++                               int substreams_present)
++{
++    GetBitContext *gb = &s->gbc;
++
++    skip_bits1(gb);
++    if (substreams_present) {
++        int substream_index = get_bits(gb, 2);
++        if (substream_index == 3)
++            substream_index += variable_bits(gb, 2);
++    }
++
++    return 0;
++}
++
++static int ac4_substream_info_chan(AC4DecodeContext *s, SubstreamGroupInfo *g,
++                                   int substreams_present,
++                                   int sus_ver)
++{
++    GetBitContext *gb = &s->gbc;
++    SubstreamInfo *ssi = &g->ssinfo;
++
++    ssi->sus_ver = sus_ver;
++    ssi->channel_mode = get_vlc2(gb, channel_mode_vlc.table, channel_mode_vlc.bits, 3);
++    av_log(s->avctx, AV_LOG_DEBUG, "channel_mode: %d\n", ssi->channel_mode);
++    if (ssi->channel_mode < 0)
++        return AVERROR_INVALIDDATA;
++
++    if (ssi->channel_mode == 16)
++        ssi->channel_mode += variable_bits(gb, 2);
++
++    if (ssi->channel_mode >= 5 && ssi->channel_mode <= 10) {
++        for (int i = 0; i < s->nb_presentations; i++) {
++            if (s->pinfo[i].presentation_version == 2) {
++                ssi->channel_mode = 1; /* immersive stereo */
++                break;
++            }
++        }
++    }
++
++    if (ssi->channel_mode == 11 ||
++        ssi->channel_mode == 12 ||
++        ssi->channel_mode == 13 ||
++        ssi->channel_mode == 14) {
++        ssi->back_channels_present = get_bits1(gb);
++        ssi->centre_present        = get_bits1(gb);
++        ssi->top_channels_present  = get_bits(gb, 2);
++    }
++
++    if (s->fs_index && get_bits1(gb))
++        ssi->sf_multiplier = 1 + get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "sf_multiplier: %d\n", ssi->sf_multiplier);
++
++    if (get_bits1(gb))
++        ssi->bitrate_indicator = get_vlc2(gb, bitrate_indicator_vlc.table, bitrate_indicator_vlc.bits, 3);
++
++    if (ssi->channel_mode == 7 ||
++        ssi->channel_mode == 8 ||
++        ssi->channel_mode == 9 ||
++        ssi->channel_mode == 10)
++        ssi->add_ch_base = get_bits1(gb);
++
++    for (int i = 0; i < s->pinfo[0].frame_rate_factor; i++) {
++        ssi->iframe[i] = get_bits1(gb);
++        av_log(s->avctx, AV_LOG_DEBUG, "iframe[%d]: %d\n", i, ssi->iframe[i]);
++    }
++
++    if (substreams_present) {
++        ssi->substream_index = get_bits(gb, 2);
++        if (ssi->substream_index == 3)
++            ssi->substream_index += variable_bits(gb, 2);
++        av_log(s->avctx, AV_LOG_DEBUG, "substream index: %d\n", ssi->substream_index);
++    }
++
++    return 0;
++}
++
++static void ac4_bed_dyn_obj_assignment(AC4DecodeContext *s, int n_signals)
++{
++    GetBitContext *gb = &s->gbc;
++    if (!get_bits1(gb)) { //b_dyn_objects_only
++        if (get_bits1(gb)) { //b_isf
++            skip_bits(gb, 3); //isf_config
++        } else {
++            if (get_bits1(gb)) { //b_ch_assign_code
++                skip_bits(gb, 3); //bed_chan_assign_code
++            } else {
++                if (get_bits1(gb)) { //b_chan_assign_mask;
++                    if (get_bits1(gb)) { //b_nonstd_bed_channel_assignment
++                        skip_bits(gb, 17); //nonstd_bed_channel_assignment_mask
++                    } else {
++                        skip_bits(gb, 10); //std_bed_channel_assignment_mask
++                    }
++                } else {
++                    int n_bed_signals;
++                    if (n_signals > 1) {
++                        n_bed_signals = get_bits_long(gb, ff_log2(n_signals)) + 1;
++                    } else {
++                        n_bed_signals = 1;
++                    }
++                    for (int i = 0; i < n_bed_signals; i++)
++                        skip_bits(gb, 4);
++                }
++            }
++        }
++    }
++}
++
++static void ac4_oamd_common_data(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (get_bits1(gb) == 0) { //b_default_screen_size_ratio;
++        skip_bits(gb, 5); //master_screen_size_ratio_code
++    }
++
++    skip_bits(gb, 1); //b_bed_object_chan_distribute
++
++    if (get_bits1(gb)) { //b_additional_data
++        int add_data_bytes = get_bits(gb, 1) + 1;
++        if (add_data_bytes == 2)
++            add_data_bytes += variable_bits(gb, 2);
++        skip_bits_long(gb, add_data_bytes * 8);
++    }
++}
++
++static int ac4_substream_info_ajoc(AC4DecodeContext *s, SubstreamInfo *ssi, int substreams_present)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssi->lfe = get_bits1(gb);
++    ssi->static_dmx = get_bits1(gb);
++
++    if (ssi->static_dmx) {
++        ssi->n_fullband_dmx_signals = 5;
++    } else {
++        ssi->n_fullband_dmx_signals = get_bits(gb, 4) + 1;
++        ac4_bed_dyn_obj_assignment(s, ssi->n_fullband_dmx_signals);
++    }
++
++    if (get_bits1(gb)) //b_oamd_common_data_present
++        ac4_oamd_common_data(s);
++
++    ssi->n_fullband_upmix_signals = get_bits(gb, 4) + 1;
++    if (ssi->n_fullband_upmix_signals == 16)
++        ssi->n_fullband_upmix_signals += variable_bits(gb, 3);
++    if (ssi->n_fullband_upmix_signals > 4096) /* arbitary value to prevent slowdowns */
++        return AVERROR_INVALIDDATA;
++
++    ac4_bed_dyn_obj_assignment(s, ssi->n_fullband_upmix_signals);
++
++    if (s->fs_index == 1) {
++        if (get_bits1(gb)) //b_sf_multiplier;
++            ssi->sf_multiplier = get_bits1(gb);
++    }
++
++    if (get_bits1(gb)) //b_bitrate_info;
++        ssi->bitrate_indicator = get_vlc2(gb, bitrate_indicator_vlc.table, bitrate_indicator_vlc.bits, 1);
++
++    for (int i = 0; i < s->pinfo[0].frame_rate_factor; i++)
++        ssi->audio_ndot[i] = get_bits1(gb);
++
++    if (substreams_present) {
++       ssi->substream_index = get_bits(gb, 2);
++       if (ssi->substream_index == 3)
++           ssi->substream_index += variable_bits(gb, 2);
++    }
++
++    return 0;
++}
++
++static int ac4_substream_info_obj(AC4DecodeContext *s, SubstreamInfo *ssi, int substreams_present)
++{
++    GetBitContext *gb = &s->gbc;
++    int n_objects_code;
++
++    n_objects_code = get_bits(gb, 3);
++    switch (n_objects_code) {
++    case 0:
++    case 1:
++    case 2:
++    case 3:
++        ssi->n_objects = ssi->lfe + n_objects_code;
++        break;
++    case 4:
++        ssi->n_objects = ssi->lfe + 5;
++        break;
++    default:
++        return AVERROR_INVALIDDATA;
++    }
++
++    if (get_bits1(gb)) { //b_dynamic_objects;
++        skip_bits1(gb); //b_lfe
++    } else {
++        if (get_bits1(gb)) { //b_bed_objects
++            if (get_bits1(gb)) { //b_bed_start
++                if (get_bits1(gb)) { //b_ch_assign_code
++                    skip_bits(gb, 3); //bed_chan_assign_code
++                } else {
++                    if (get_bits1(gb)) { //b_nonstd_bed_channel_assignment
++                        skip_bits(gb, 17); //nonstd_bed_channel_assignment_mask
++                    } else {
++                        skip_bits(gb, 10); //std_bed_channel_assignment_mask
++                    }
++                }
++            }
++        } else {
++            if (get_bits1(gb)) { //b_isf
++                if (get_bits1(gb)) { //b_isf_start
++                    skip_bits(gb, 3); //isf_config
++                }
++            } else {
++                int res_bytes = get_bits(gb, 4);
++                skip_bits_long(gb, 8*res_bytes); //reserved_data
++            }
++        }
++    }
++
++    if (s->fs_index == 1) {
++        if (get_bits1(gb)) //b_sf_multiplier;
++            ssi->sf_multiplier = get_bits1(gb);
++    }
++
++    if (get_bits1(gb)) //b_bitrate_info;
++        ssi->bitrate_indicator = get_vlc2(gb, bitrate_indicator_vlc.table, bitrate_indicator_vlc.bits, 1);
++
++    for (int i = 0; i < s->pinfo[0].frame_rate_factor; i++) {
++        skip_bits1(gb); //b_audio_ndot
++    }
++
++    if (substreams_present) {
++       ssi->substream_index = get_bits(gb, 2);
++       if (ssi->substream_index == 3)
++           ssi->substream_index += variable_bits(gb, 2);
++    }
++
++    return 0;
++}
++
++static int ac4_substream_group_info(AC4DecodeContext *s,
++                                    SubstreamGroupInfo *g)
++{
++    GetBitContext *gb = &s->gbc;
++    int substreams_present;
++    int n_lf_substreams;
++    int hsf_ext;
++    int sus_ver;
++    int ret;
++
++    substreams_present = get_bits1(gb);
++    hsf_ext = get_bits1(gb);
++    if (get_bits1(gb)) {
++        n_lf_substreams = 1;
++    } else {
++        n_lf_substreams = get_bits(gb, 2) + 2;
++        if (n_lf_substreams == 5) {
++            n_lf_substreams += variable_bits(gb, 2);
++            if (n_lf_substreams > 16) /* arbitary limit to prevent slowdowns */
++                 return AVERROR_INVALIDDATA;
++        }
++    }
++
++    g->channel_coded = get_bits1(gb);
++    g->ajoc = 0;
++    if (g->channel_coded) {
++        for (int sus = 0; sus < n_lf_substreams; sus++) {
++            if (s->version == 1) {
++                sus_ver = get_bits1(gb);
++            } else {
++                sus_ver = 1;
++            }
++
++            ret = ac4_substream_info_chan(s, g, substreams_present, sus_ver);
++            if (ret < 0)
++                return ret;
++            if (hsf_ext)
++                ac4_hsf_ext_substream_info(s, &g->ssinfo, substreams_present);
++        }
++    } else {
++        if (get_bits1(gb))
++            oamd_substream_info(s, g, substreams_present);
++        for (int sus = 0; sus < n_lf_substreams; sus++) {
++            if (get_bits1(gb)) {
++                g->ajoc = 1;
++                if ((ret = ac4_substream_info_ajoc(s, &g->ssinfo, substreams_present)) < 0)
++                    return ret;
++            } else {
++                ac4_substream_info_obj(s, &g->ssinfo, substreams_present);
++            }
++            if (hsf_ext)
++                ac4_hsf_ext_substream_info(s, &g->ssinfo, substreams_present);
++        }
++    }
++
++    if (get_bits1(gb))
++        content_type(s, NULL);
++
++    return 0;
++}
++
++static int ac4_sgi_specifier(AC4DecodeContext *s, SubstreamGroupInfo *g)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (s->version == 1) {
++        ac4_substream_group_info(s, g);
++        //FIXME: g->group_index = ?
++    } else {
++        g->group_index = get_bits(gb, 3);
++        if (g->group_index == 7)
++            g->group_index += variable_bits(gb, 2);
++    }
++
++    s->total_groups = FFMAX(s->total_groups, g->group_index);
++
++    return 0;
++}
++
++static int ac4_presentation_v1_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++    int single_substream_group, ret;
++
++    single_substream_group = get_bits1(gb);
++    if (single_substream_group != 1) {
++        p->presentation_config = get_bits(gb, 3);
++        if (p->presentation_config == 7)
++            p->presentation_config += variable_bits(gb, 2);
++    }
++    if (s->version != 1)
++        p->presentation_version = get_unary(gb, 0, 31);
++
++    av_log(s->avctx, AV_LOG_DEBUG, "presentation version: %d\n", p->presentation_version);
++    s->total_groups = 0;
++
++    if (single_substream_group != 1 && p->presentation_config == 6) {
++        p->add_emdf_substreams = 1;
++        av_log(s->avctx, AV_LOG_DEBUG, "add_emdf_substreams\n");
++    } else {
++        if (s->version != 1)
++            p->mdcompat = get_bits(gb, 3);
++
++        if (get_bits1(gb))
++            p->presentation_id = variable_bits(gb, 2);
++
++        frame_rate_multiply_info(s, p);
++        frame_rate_fractions_info(s, p);
++        emdf_info(s, &p->emdf[0]);
++
++        if (get_bits1(gb))
++            p->enable_presentation = get_bits1(gb);
++
++        if (single_substream_group == 1) {
++            ac4_sgi_specifier(s, &s->ssgroup[0]);
++            av_log(s->avctx, AV_LOG_DEBUG, "single substream group\n");
++            p->n_substream_groups = 1;
++        } else {
++            p->multi_pid = get_bits1(gb);
++            switch (p->presentation_config) {
++            case 0:
++                /* Music and Effects + Dialogue */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                p->n_substream_groups = 2;
++                break;
++            case 1:
++                /* Main + DE */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                p->n_substream_groups = 1;
++                break;
++            case 2:
++                /* Main + Associated Audio */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                p->n_substream_groups = 2;
++                break;
++            case 3:
++                /* Music and Effects + Dialogue + Associated Audio */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                ac4_sgi_specifier(s, &s->ssgroup[2]);
++                p->n_substream_groups = 3;
++                break;
++            case 4:
++                /* Main + DE + Associated Audio */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                ac4_sgi_specifier(s, &s->ssgroup[2]);
++                p->n_substream_groups = 2;
++                break;
++            case 5:
++                /* Arbitrary number of roles and substream groups */
++                p->n_substream_groups = get_bits(gb, 2) + 2;
++                if (p->n_substream_groups == 5)
++                    p->n_substream_groups += variable_bits(gb, 2);
++                if (p->n_substream_groups > FF_ARRAY_ELEMS(s->ssgroup))
++                    return AVERROR_INVALIDDATA;
++
++                for (int sg = 0; sg < p->n_substream_groups; sg++)
++                    ac4_sgi_specifier(s, &s->ssgroup[sg]);
++                break;
++            default:
++                /* EMDF and other data */
++                presentation_config_ext_info(s);
++                break;
++            }
++        }
++        p->pre_virtualized = get_bits1(gb);
++        p->add_emdf_substreams = get_bits1(gb);
++        if ((ret = presentation_substream_info(s, &p->psinfo)) < 0)
++            return ret;
++    }
++
++    if (p->add_emdf_substreams) {
++        p->n_add_emdf_substreams = get_bits(gb, 2);
++        if (p->n_add_emdf_substreams == 0)
++            p->n_add_emdf_substreams = variable_bits(gb, 2) + 4;
++        if (p->n_add_emdf_substreams > FF_ARRAY_ELEMS(p->emdf))
++            return AVERROR_INVALIDDATA;
++
++        for (int i = 0; i < p->n_add_emdf_substreams; i++)
++            emdf_info(s, &p->emdf[i]);
++    }
++
++    return 0;
++}
++
++static int get_num_ts_in_ats(int frame_length)
++{
++    if (frame_length <= 2048 && frame_length >= 1536)
++        return 2;
++
++    return 1;
++}
++
++static int ac4_toc(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    s->version = get_bits(gb, 2);
++    if (s->version == 3)
++        s->version += variable_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "bitstream version: %d\n", s->version);
++    s->sequence_counter_prev = s->sequence_counter;
++    s->sequence_counter = get_bits(gb, 10);
++    av_log(s->avctx, AV_LOG_DEBUG, "sequence counter: %d\n", s->sequence_counter);
++
++    s->wait_frames = get_bits1(gb);
++    if (s->wait_frames) {
++        s->nb_wait_frames = get_bits(gb, 3);
++        if (s->nb_wait_frames > 0)
++            skip_bits(gb, 2);
++    }
++
++    s->fs_index = get_bits1(gb);
++    s->frame_rate_index = get_bits(gb, 4);
++    av_log(s->avctx, AV_LOG_DEBUG, "frame_rate_index: %d\n", s->frame_rate_index);
++    s->frame_len_base = frame_len_base_48khz[s->frame_rate_index];
++    s->num_ts_in_ats = get_num_ts_in_ats(s->frame_len_base);
++    s->frame_len_base_idx = frame_len_base_idx_48khz[s->frame_rate_index];
++    av_log(s->avctx, AV_LOG_DEBUG, "frame_len_base: %d\n", s->frame_len_base);
++    s->resampling_ratio = resampling_ratios[s->frame_rate_index];
++    s->num_qmf_timeslots = s->frame_len_base / MAX_QMF_BANDS;
++    s->num_aspx_timeslots = s->num_qmf_timeslots / s->num_ts_in_ats;
++    av_log(s->avctx, AV_LOG_DEBUG, "num_aspx_timeslots: %d\n", s->num_aspx_timeslots);
++    s->ts_offset_hfgen = 3 * s->num_ts_in_ats;
++    s->iframe_global = get_bits1(gb);
++    if (s->iframe_global) {
++        s->have_iframe = 1;
++    } else {
++        ret = check_sequence(s);
++        if (ret < 0)
++            return ret;
++    }
++    if (get_bits1(gb)) {
++        s->nb_presentations = 1;
++    } else {
++        if (get_bits1(gb)) {
++            s->nb_presentations = 2 + variable_bits(gb, 2);
++            if (s->nb_presentations > FF_ARRAY_ELEMS(s->pinfo))
++                return AVERROR_INVALIDDATA;
++        } else {
++            s->nb_presentations = 0;
++        }
++    }
++
++    s->payload_base = 0;
++    if (get_bits1(gb)) {
++        s->payload_base = get_bits(gb, 5) + 1;
++        if (s->payload_base == 0x20) {
++            s->payload_base += variable_bits(gb, 3);
++        }
++    }
++
++    av_log(s->avctx, AV_LOG_DEBUG, "presentations: %d\n", s->nb_presentations);
++
++    if (s->version <= 1) {
++        for (int i = 0; i < s->nb_presentations; i++) {
++            ret = ac4_presentation_info(s, &s->pinfo[i]);
++            if (ret < 0)
++                return ret;
++        }
++    } else {
++        if (get_bits1(gb)) {
++            s->short_program_id = get_bits(gb, 16);
++            if (get_bits1(gb)) {
++                skip_bits_long(gb, 16 * 8);
++            }
++        }
++
++        for (int i = 0; i < s->nb_presentations; i++) {
++            ret = ac4_presentation_v1_info(s, &s->pinfo[i]);
++            if (ret < 0)
++                return ret;
++        }
++
++        if (s->total_groups + 1 >= FF_ARRAY_ELEMS(s->ssgroup))
++            return AVERROR_INVALIDDATA;
++
++        av_log(s->avctx, AV_LOG_DEBUG, "total_groups: %d\n", s->total_groups + 1);
++        for (int i = 0; i <= s->total_groups; i++) {
++            ret = ac4_substream_group_info(s, &s->ssgroup[i]);
++            if (ret < 0)
++                return ret;
++        }
++    }
++
++    substream_index_table(s);
++
++    align_get_bits(gb);
++
++    av_log(s->avctx, AV_LOG_DEBUG, "TOC size: %d\n", get_bits_count(gb) >> 3);
++
++    return 0;
++}
++
++static int sb_to_pb(int acpl_num_param_bands_id, int acpl_qmf_band)
++{
++    if (acpl_qmf_band >= 0 &&
++        acpl_qmf_band <= 8)
++        return qmf_subbands[acpl_qmf_band][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 9 &&
++        acpl_qmf_band <= 10)
++        return qmf_subbands[9][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 11 &&
++        acpl_qmf_band <= 13)
++        return qmf_subbands[10][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 14 &&
++        acpl_qmf_band <= 17)
++        return qmf_subbands[11][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 18 &&
++        acpl_qmf_band <= 22)
++        return qmf_subbands[12][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 23 &&
++        acpl_qmf_band <= 34)
++        return qmf_subbands[13][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 35 &&
++        acpl_qmf_band <= 63)
++        return qmf_subbands[14][acpl_num_param_bands_id];
++    return 0;
++}
++
++static int acpl_config_1ch(AC4DecodeContext *s, Substream *ss, int mode)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ss->acpl_qmf_band = 0;
++    ss->acpl_param_band = 0;
++    ss->acpl_num_param_bands_id = get_bits(gb, 2);
++    ss->acpl_quant_mode[0] = get_bits1(gb);
++    if (mode == ACPL_PARTIAL) {
++        ss->acpl_qmf_band = get_bits(gb, 3) + 1;
++        ss->acpl_param_band = sb_to_pb(ss->acpl_num_param_bands_id, ss->acpl_qmf_band);
++    }
++
++    return 0;
++}
++
++static int acpl_config_2ch(AC4DecodeContext *s, Substream *ss)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ss->acpl_qmf_band = 0;
++    ss->acpl_param_band = 0;
++    ss->acpl_num_param_bands_id = get_bits(gb, 2);
++    ss->acpl_quant_mode[0] = get_bits1(gb);
++    ss->acpl_quant_mode[1] = get_bits1(gb);
++
++    return 0;
++}
++
++static void aspx_config(AC4DecodeContext *s, Substream *ss)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ss->aspx_quant_mode_env = get_bits1(gb);
++    ss->prev_aspx_start_freq = ss->aspx_start_freq;
++    ss->aspx_start_freq = get_bits(gb, 3);
++    ss->prev_aspx_stop_freq = ss->aspx_stop_freq;
++    ss->aspx_stop_freq = get_bits(gb, 2);
++    ss->prev_aspx_master_freq_scale = ss->aspx_master_freq_scale;
++    ss->aspx_master_freq_scale = get_bits1(gb);
++    ss->aspx_interpolation = get_bits1(gb);
++    ss->aspx_preflat = get_bits1(gb);
++    ss->aspx_limiter = get_bits1(gb);
++    ss->aspx_noise_sbg = get_bits(gb, 2);
++    ss->aspx_num_env_bits_fixfix = get_bits1(gb);
++    ss->aspx_freq_res_mode = get_bits(gb, 2);
++}
++
++static int get_transfer_length_from_idx(AC4DecodeContext *s, int idx)
++{
++    const uint16_t *transf_length_tab;
++
++    switch (s->frame_len_base) {
++    case 2048:
++        transf_length_tab = transf_length_48khz_2048;
++        break;
++    case 1920:
++        transf_length_tab = transf_length_48khz_1920;
++        break;
++    case 1536:
++        transf_length_tab = transf_length_48khz_1536;
++        break;
++    case 1024:
++        transf_length_tab = transf_length_48khz_1024;
++        break;
++    case 960:
++        transf_length_tab = transf_length_48khz_960;
++        break;
++    case 768:
++        transf_length_tab = transf_length_48khz_768;
++        break;
++    case 512:
++        transf_length_tab = transf_length_48khz_512;
++        break;
++    case 384:
++        transf_length_tab = transf_length_48khz_384;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    return transf_length_tab[idx];
++}
++
++static int asf_transform_info(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (s->frame_len_base >= 1536) {
++        ssch->scp.long_frame = get_bits1(gb);
++        if (ssch->scp.long_frame == 0) {
++            ssch->scp.transf_length_idx[0] = get_bits(gb, 2);
++            ssch->scp.transf_length_idx[1] = get_bits(gb, 2);
++            ssch->scp.transf_length[0] = get_transfer_length_from_idx(s, ssch->scp.transf_length_idx[0]);
++            ssch->scp.transf_length[1] = get_transfer_length_from_idx(s, ssch->scp.transf_length_idx[1]);
++        } else {
++            ssch->scp.transf_length[0] = s->frame_len_base;
++            ssch->scp.transf_length[1] = 0;
++        }
++    } else {
++        ssch->scp.long_frame = 0;
++        ssch->scp.transf_length_idx[0] = get_bits(gb, 2);
++        ssch->scp.transf_length[0] = get_transfer_length_from_idx(s, ssch->scp.transf_length_idx[0]);
++    }
++
++    return 0;
++}
++
++static int get_msfbl_bits(int transf_length)
++{
++    if (transf_length <= 2048 && transf_length >= 1536)
++        return 3;
++
++    return 2;
++}
++
++static int get_grp_bits(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    if (s->frame_len_base >= 1536 && ssch->scp.long_frame == 1)
++        return 0;
++
++    if (s->frame_len_base >= 1536 && ssch->scp.long_frame == 0) {
++        if (ssch->scp.transf_length_idx[0] >= FF_ARRAY_ELEMS(n_grp_bits_a))
++            return AVERROR_INVALIDDATA;
++        if (ssch->scp.transf_length_idx[1] >= FF_ARRAY_ELEMS(n_grp_bits_a[0]))
++            return AVERROR_INVALIDDATA;
++
++        return n_grp_bits_a[ssch->scp.transf_length_idx[0]][ssch->scp.transf_length_idx[1]];
++    }
++
++    if (s->frame_len_base < 1536 && s->frame_len_base > 512) {
++        if (ssch->scp.transf_length_idx[0] >= FF_ARRAY_ELEMS(n_grp_bits_b))
++            return AVERROR_INVALIDDATA;
++
++        return n_grp_bits_b[ssch->scp.transf_length_idx[0]];
++    }
++
++    if (s->frame_len_base <= 512) {
++        if (ssch->scp.transf_length_idx[0] >= FF_ARRAY_ELEMS(n_grp_bits_b))
++            return AVERROR_INVALIDDATA;
++
++        return n_grp_bits_c[ssch->scp.transf_length_idx[0]];
++    }
++
++    return 0;
++}
++
++static int get_msfb_bits(int transf_length)
++{
++    if (transf_length <= 2048 && transf_length >= 384)
++        return 6;
++
++    if (transf_length <= 256 && transf_length >= 192)
++        return 5;
++
++    return 4;
++}
++
++static int get_side_bits(int transf_length)
++{
++    if (transf_length <= 2048 && transf_length >= 480)
++        return 5;
++
++    if (transf_length <= 384 && transf_length >= 240)
++        return 4;
++
++    return 3;
++}
++
++static int get_max_sfb(AC4DecodeContext *s, SubstreamChannel *ssch,
++                       int g)
++{
++    int idx = 0;
++
++    if (s->frame_len_base >= 1536 && (ssch->scp.long_frame == 0) &&
++        (ssch->scp.transf_length_idx[0] != ssch->scp.transf_length_idx[1])) {
++        int num_windows_0 = 1 << (3 - ssch->scp.transf_length_idx[0]);
++
++        if (g >= ssch->scp.window_to_group[num_windows_0])
++            idx = 1;
++    }
++
++    if ((ssch->scp.side_limited == 1) ||
++        (ssch->scp.dual_maxsfb == 1 && ssch->scp.side_channel == 1))  {
++        return ssch->scp.max_sfb_side[idx];
++    } else {
++        return ssch->scp.max_sfb[idx];
++    }
++}
++
++static int get_transf_length(AC4DecodeContext *s, SubstreamChannel *ssch, int g, int *idx)
++{
++    const uint16_t *transf_length_tab;
++
++    switch (s->frame_len_base) {
++    case 2048:
++        transf_length_tab = transf_length_48khz_2048;
++        break;
++    case 1920:
++        transf_length_tab = transf_length_48khz_1920;
++        break;
++    case 1536:
++        transf_length_tab = transf_length_48khz_1536;
++        break;
++    case 1024:
++        transf_length_tab = transf_length_48khz_1024;
++        break;
++    case 960:
++        transf_length_tab = transf_length_48khz_960;
++        break;
++    case 768:
++        transf_length_tab = transf_length_48khz_768;
++        break;
++    case 512:
++        transf_length_tab = transf_length_48khz_512;
++        break;
++    case 384:
++        transf_length_tab = transf_length_48khz_384;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    if (s->frame_len_base >= 1536) {
++        if (ssch->scp.long_frame == 0) {
++            int num_windows_0 = 1 << (3 - ssch->scp.transf_length_idx[0]);
++
++            if (g < ssch->scp.window_to_group[num_windows_0]) {
++                if (idx)
++                    *idx = ssch->scp.transf_length_idx[0];
++                return transf_length_tab[ssch->scp.transf_length_idx[0]];
++            } else {
++                if (idx)
++                    *idx = ssch->scp.transf_length_idx[1];
++                return transf_length_tab[ssch->scp.transf_length_idx[1]];
++            }
++        } else {
++            if (idx)
++                *idx = 4;
++            return s->frame_len_base; // long frame, the transform length equals to frame_length
++        }
++    } else {
++        if (idx)
++            *idx = ssch->scp.transf_length_idx[0];
++        return transf_length_tab[ssch->scp.transf_length_idx[0]];
++    }
++}
++
++static int get_sfb_size(int transf_length)
++{
++    switch (transf_length) {
++    case 2048:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_2048);
++        break;
++    case 1920:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_1920);
++        break;
++    case 1536:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_1536);
++        break;
++    case 1024:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_1024);
++        break;
++    case 960:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_960);
++        break;
++    case 768:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_768);
++        break;
++    case 512:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_512);
++        break;
++    case 480:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_480);
++        break;
++    case 384:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_384);
++        break;
++    case 256:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_256);
++        break;
++    case 240:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_240);
++        break;
++    case 192:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_192);
++        break;
++    case 128:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_128);
++        break;
++    case 120:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_120);
++        break;
++    case 96:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_96);
++        break;
++    default:
++        av_assert0(0);
++    }
++    return 0;
++}
++
++static const uint16_t *get_sfb_offset(int transf_length)
++{
++    switch (transf_length) {
++    case 2048:
++        return sfb_offset_48khz_2048;
++        break;
++    case 1920:
++        return sfb_offset_48khz_1920;
++        break;
++    case 1536:
++        return sfb_offset_48khz_1536;
++        break;
++    case 1024:
++        return sfb_offset_48khz_1024;
++        break;
++    case 960:
++        return sfb_offset_48khz_960;
++        break;
++    case 768:
++        return sfb_offset_48khz_768;
++        break;
++    case 512:
++        return sfb_offset_48khz_512;
++        break;
++    case 480:
++        return sfb_offset_48khz_480;
++        break;
++    case 384:
++        return sfb_offset_48khz_384;
++        break;
++    case 256:
++        return sfb_offset_48khz_256;
++        break;
++    case 240:
++        return sfb_offset_48khz_240;
++        break;
++    case 192:
++        return sfb_offset_48khz_192;
++        break;
++    case 128:
++        return sfb_offset_48khz_128;
++        break;
++    case 120:
++        return sfb_offset_48khz_120;
++        break;
++    case 96:
++        return sfb_offset_48khz_96;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    return NULL;
++}
++
++/*
++static int num_sfb_96(int transf_length)
++{
++    if (transf_length >= 4096)
++        return 79;
++    else if (transf_length >= 3840)
++        return 76;
++    else if (transf_length >= 3072)
++        return 67;
++    else if (transf_length >= 2048)
++        return 57;
++    else if (transf_length >= 1920)
++        return 57;
++    else if (transf_length >= 1536)
++        return 49;
++    else if (transf_length >= 1024)
++        return 44;
++    else if (transf_length >= 920)
++        return 44;
++    else if (transf_length >= 768)
++        return 39;
++    else if (transf_length >= 512)
++        return 28;
++    else if (transf_length >= 480)
++        return 28;
++    else if (transf_length >= 384)
++        return 24;
++    else if (transf_length >= 256)
++        return 22;
++    else if (transf_length >= 240)
++        return 22;
++    else
++        return 18;
++}
++*/
++
++static int num_sfb_48(int transf_length)
++{
++    switch (transf_length) {
++    case 2048:
++        return 63; break;
++    case 1920:
++        return 61; break;
++    case 1536:
++        return 55; break;
++    case 1024:
++    case 960:
++        return 49; break;
++    case 768:
++        return 43; break;
++    case 512:
++    case 480:
++        return 36; break;
++    case 384:
++        return 33; break;
++    case 256:
++    case 240:
++        return 20; break;
++    case 192:
++        return 18; break;
++    case 128:
++    case 120:
++        return 14; break;
++    case 96:
++        return 12; break;
++    default:
++        av_assert0(0);
++    }
++
++    return 0;
++}
++
++static int asf_psy_elements(AC4DecodeContext *s, Substream *ss,
++                            SubstreamChannel *ssch, int n_grp_bits)
++{
++    int group_offset, win_offset, win;
++
++    ssch->scp.num_windows = 1;
++    ssch->scp.num_window_groups = 1;
++    ssch->scp.window_to_group[0] = 0;
++
++    if (ssch->scp.long_frame == 0) {
++        ssch->scp.num_windows = n_grp_bits + 1;
++        if (ssch->scp.different_framing) {
++            int num_windows_0 = 1 << (3 - ssch->scp.transf_length_idx[0]);
++
++            for (int i = n_grp_bits; i >= num_windows_0; i--) {
++                ssch->scp.scale_factor_grouping[i] = ssch->scp.scale_factor_grouping[i - 1];
++            }
++
++            ssch->scp.scale_factor_grouping[num_windows_0 - 1] = 0;
++            ssch->scp.num_windows++;
++        }
++
++        for (int i = 0; i < ssch->scp.num_windows - 1; i++) {
++            if (ssch->scp.scale_factor_grouping[i] == 0)
++                ssch->scp.num_window_groups++;
++
++            ssch->scp.window_to_group[i + 1] = ssch->scp.num_window_groups - 1;
++        }
++    }
++
++    group_offset = 0;
++    win_offset = 0;
++    win = 0;
++    memset(ssch->offset2sfb, 0, sizeof(ssch->offset2sfb));
++    memset(ssch->offset2g, 0, sizeof(ssch->offset2g));
++
++    av_assert2(ssch->scp.num_window_groups <= 16);
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int transf_length_g = get_transf_length(s, ssch, g, NULL);
++        const uint16_t *sfb_offset = get_sfb_offset(transf_length_g);
++        const int sfb_max_size = get_sfb_size(transf_length_g);
++        int max_sfb;
++
++        if (!sfb_offset)
++            return AVERROR_INVALIDDATA;
++
++        ssch->scp.num_win_in_group[g] = 0;
++        for (int w = 0; w < ssch->scp.num_windows; w++) {
++            if (ssch->scp.window_to_group[w] == g)
++                ssch->scp.num_win_in_group[g]++;
++        }
++
++        max_sfb = get_max_sfb(s, ssch, g);
++        if (max_sfb >= sfb_max_size) {
++            av_log(s->avctx, AV_LOG_ERROR, "max_sfb=%d > sfb_max_size=%d\n", max_sfb, sfb_max_size);
++            return AVERROR_INVALIDDATA;
++        }
++        for (int sfb = 0; sfb < max_sfb; sfb++)
++            ssch->sect_sfb_offset[g][sfb] = group_offset + sfb_offset[sfb] * ssch->scp.num_win_in_group[g];
++        group_offset += sfb_offset[max_sfb] * ssch->scp.num_win_in_group[g];
++        ssch->sect_sfb_offset[g][max_sfb] = group_offset;
++        for (int sfb = 0; sfb < max_sfb; sfb++) {
++            av_assert2(sfb + 1 < FF_ARRAY_ELEMS(ssch->sect_sfb_offset[g]));
++            for (int j = ssch->sect_sfb_offset[g][sfb]; j < ssch->sect_sfb_offset[g][sfb+1]; j++) {
++                av_assert2(j >= 0 && j < FF_ARRAY_ELEMS(ssch->offset2sfb));
++                av_assert2(j >= 0 && j < FF_ARRAY_ELEMS(ssch->offset2g));
++                if (j >= FF_ARRAY_ELEMS(ssch->offset2g))
++                    return AVERROR_INVALIDDATA;
++                ssch->offset2sfb[j] = sfb;
++                ssch->offset2g[j] = g;
++            }
++        }
++
++        for (int w = 0; w < ssch->scp.num_win_in_group[g]; w++) {
++            av_assert2(win + w >= 0 && win + w < FF_ARRAY_ELEMS(ssch->win_offset));
++            ssch->win_offset[win + w] = win_offset;
++            win_offset += transf_length_g;
++        }
++        win += ssch->scp.num_win_in_group[g];
++    }
++    av_assert2(win_offset == s->frame_len_base);
++
++    av_log(s->avctx, AV_LOG_DEBUG, "long_frame: %d\n", ssch->scp.long_frame);
++    av_log(s->avctx, AV_LOG_DEBUG, "different_framing: %d\n", ssch->scp.different_framing);
++    av_log(s->avctx, AV_LOG_DEBUG, "num_windows: %d\n", ssch->scp.num_windows);
++    av_log(s->avctx, AV_LOG_DEBUG, "num_window_groups: %d\n", ssch->scp.num_window_groups);
++    av_log(s->avctx, AV_LOG_DEBUG, "transf_lengths:");
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        av_log(s->avctx, AV_LOG_DEBUG, " %d", get_transf_length(s, ssch, g, NULL));
++    }
++    av_log(s->avctx, AV_LOG_DEBUG, "\n");
++    av_log(s->avctx, AV_LOG_DEBUG, "num_win_in_group:");
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        av_log(s->avctx, AV_LOG_DEBUG, " %d", ssch->scp.num_win_in_group[g]);
++    }
++    av_log(s->avctx, AV_LOG_DEBUG, "\n");
++
++    return 0;
++}
++
++static int asf_psy_info(AC4DecodeContext *s, Substream *ss,
++                        SubstreamChannel *ssch,
++                        int dual_maxsfb, int side_limited)
++{
++    GetBitContext *gb = &s->gbc;
++    int n_side_bits = get_side_bits(ssch->scp.transf_length[0]);
++    int n_msfb_bits = get_msfb_bits(ssch->scp.transf_length[0]);
++    int n_grp_bits = get_grp_bits(s, ssch);
++
++    av_log(s->avctx, AV_LOG_DEBUG, "n_grp_bits: %d\n", n_grp_bits);
++    if (n_grp_bits < 0)
++        return n_grp_bits;
++
++    ssch->scp.different_framing = 0;
++    if ((s->frame_len_base >= 1536) && (ssch->scp.long_frame == 0) &&
++        (ssch->scp.transf_length_idx[0] != ssch->scp.transf_length_idx[1])) {
++        ssch->scp.different_framing = 1;
++    }
++
++    if (side_limited) {
++        ssch->scp.max_sfb_side[0] = get_bits(gb, n_side_bits);
++    } else {
++        ssch->scp.max_sfb[0] = get_bits(gb, n_msfb_bits);
++        if (dual_maxsfb)
++            ssch->scp.max_sfb_side[0] = get_bits(gb, n_msfb_bits);
++    }
++
++    if (ssch->scp.different_framing) {
++        n_side_bits = get_side_bits(ssch->scp.transf_length[1]);
++        n_msfb_bits = get_msfb_bits(ssch->scp.transf_length[1]);
++
++        if (side_limited) {
++            ssch->scp.max_sfb_side[1] = get_bits(gb, n_side_bits);
++        } else {
++            ssch->scp.max_sfb[1] = get_bits(gb, n_msfb_bits);
++            if (dual_maxsfb)
++                ssch->scp.max_sfb_side[1] = get_bits(gb, n_msfb_bits);
++        }
++    }
++
++    memset(ssch->scp.scale_factor_grouping, 0, sizeof(ssch->scp.scale_factor_grouping));
++    for (int i = 0; i < n_grp_bits; i++)
++        ssch->scp.scale_factor_grouping[i] = get_bits1(gb);
++
++    return asf_psy_elements(s, ss, ssch, n_grp_bits);
++}
++
++static int sf_info(AC4DecodeContext *s, Substream *ss,
++                   int ch_id, int spec_frontend, int dual_maxsfb,
++                   int side_limited)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    int ret = 0;
++
++    ssch->scp.dual_maxsfb = dual_maxsfb;
++    ssch->scp.side_limited = side_limited;
++
++    if (spec_frontend == SF_ASF) {
++        asf_transform_info(s, ss, ssch);
++        ret = asf_psy_info(s, ss, ssch, dual_maxsfb, side_limited);
++    }
++
++    return ret;
++}
++
++static int sap_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memset(ssch->sap_coeff_used, 0, sizeof(ssch->sap_coeff_used));
++    memset(ssch->dpcm_alpha_q, 0, sizeof(ssch->dpcm_alpha_q));
++
++    if (!get_bits1(gb)) {
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int max_sfb_g = get_max_sfb(s, ssch, g);
++
++            for (int sfb = 0; sfb < max_sfb_g; sfb += 2) {
++                ssch->sap_coeff_used[g][sfb] = get_bits1(gb);
++                if (sfb + 1 < max_sfb_g)
++                    ssch->sap_coeff_used[g][sfb + 1] = ssch->sap_coeff_used[g][sfb];
++            }
++        }
++    } else {
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int max_sfb_g = get_max_sfb(s, ssch, g);
++
++            for (int sfb = 0; sfb < max_sfb_g; sfb++)
++                ssch->sap_coeff_used[g][sfb] = 1;
++        }
++    }
++
++    ssch->delta_code_time = 0;
++    if (ssch->scp.num_window_groups != 1)
++        ssch->delta_code_time = get_bits1(gb);
++
++    av_assert2(ssch->scp.num_window_groups <= FF_ARRAY_ELEMS(ssch->dpcm_alpha_q));
++    av_assert2(ssch->scp.num_window_groups <= FF_ARRAY_ELEMS(ssch->sap_coeff_used));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int max_sfb_g = get_max_sfb(s, ssch, g);
++
++        av_assert2(max_sfb_g <= FF_ARRAY_ELEMS(ssch->dpcm_alpha_q[0]));
++        av_assert2(max_sfb_g <= FF_ARRAY_ELEMS(ssch->sap_coeff_used[0]));
++        for (int sfb = 0; sfb < max_sfb_g; sfb += 2) {
++            if (ssch->sap_coeff_used[g][sfb]) {
++                int v = get_vlc2(gb, scale_factors_vlc.table,
++                                 scale_factors_vlc.bits, 3);
++                if (v < 0)
++                    return AVERROR_INVALIDDATA;
++
++                ssch->dpcm_alpha_q[g][sfb] = v;
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int ssf_st_data(AC4DecodeContext *s, Substream *ss,
++                       SubstreamChannel *ssch, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int num_blocks;
++
++    ssch->env_idx[0] = get_bits(gb, 5);
++    if (iframe == 1 && ssch->stride_flag == SHORT_STRIDE)
++        get_bits(gb, 5);
++
++    if (ssch->stride_flag == SHORT_STRIDE) {
++        for (int block = 0; block < 4; block++)
++            ssch->gain_bits[block] = get_bits(gb, 4);
++    }
++
++    num_blocks = (ssch->stride_flag == SHORT_STRIDE) ? 4 : 1;
++
++    for (int block = 0; block < num_blocks; block++) {
++        if (block >= ssch->start_block && block < ssch->end_block) {
++            if (ssch->predictor_presence[block]) {
++                if (ssch->delta[block])
++                    ssch->predictor_lag_delta[block] = get_bits(gb, 4);
++                else
++                    ssch->predictor_lag[block] = get_bits(gb, 9);
++            }
++        }
++        ssch->variance_preserving[block] = get_bits1(gb);
++        ssch->alloc_offset[block] = get_bits(gb, 5);
++    }
++
++    return 0;
++}
++
++static int ac_init(AC4DecodeContext *s, ACState *acs)
++{
++    GetBitContext *gb = &s->gbc;
++
++    acs->ui_model_bits = SSF_MODEL_BITS;
++    acs->ui_model_unit = SSF_MODEL_UNIT;
++    acs->ui_range_bits = SSF_RANGE_BITS;
++    acs->ui_threshold_large = SSF_THRESHOLD_LARGE;
++    acs->ui_threshold_small = SSF_THRESHOLD_SMALL;
++
++    acs->ui_low = 0;
++    acs->ui_range = SSF_THRESHOLD_LARGE;
++
++    acs->ui_offset = get_bits1(gb);
++    for (int index = 1; index < acs->ui_range_bits; index++) {
++        uint32_t ui_tmp = get_bits1(gb);
++
++        acs->ui_offset <<= 1;
++        acs->ui_offset += ui_tmp;
++    }
++
++    acs->ui_offset2 = acs->ui_offset;
++
++    return 0;
++}
++
++static int32_t ac_decode(AC4DecodeContext *s, uint32_t cdf_low,
++                         uint32_t cdf_high, ACState *acs)
++{
++    GetBitContext *gb = &s->gbc;
++    uint32_t ui_tmp1, ui_tmp2;
++    uint32_t ui_range;
++
++    ui_range = acs->ui_range >> acs->ui_model_bits;
++    ui_tmp1 = ui_range * cdf_low;
++    acs->ui_offset = acs->ui_offset - ui_tmp1;
++
++    if (cdf_high < acs->ui_model_unit) {
++        ui_tmp2 = cdf_high - cdf_low;
++        acs->ui_range = ui_range * ui_tmp2;
++    } else {
++        acs->ui_range = acs->ui_range - ui_tmp1;
++    }
++
++    // denormalize
++    while (acs->ui_range <= acs->ui_threshold_small) {
++        /* Read a single bit from the bitstream */
++        uint32_t ui_tmp1 = get_bits1(gb);
++
++        acs->ui_range <<= 1;
++        acs->ui_offset <<= 1;
++        acs->ui_offset += ui_tmp1;
++        acs->ui_offset2 <<= 1;
++        if (acs->ui_offset & 1)
++            acs->ui_offset2++;
++    }
++
++    return 0;
++}
++
++static int32_t ac_decode_finish(ACState *acs)
++
++{
++    uint32_t fact, ui_bits, ui_val;
++    uint32_t ui_tmp1, ui_tmp2, ui_rev_idx;
++
++    acs->ui_low = acs->ui_offset & (acs->ui_threshold_large-1);
++
++    ui_tmp1 = acs->ui_threshold_large - acs->ui_offset;
++
++    acs->ui_low +=ui_tmp1;
++
++    for (int bit_idx = 1; bit_idx <= acs->ui_range_bits; bit_idx++) {
++        ui_rev_idx = acs->ui_range_bits - bit_idx;
++        fact = 1U << ui_rev_idx;
++        fact = fact - 1U;
++        ui_tmp1 = acs->ui_low + fact;
++        ui_bits = ui_tmp1 >> ui_rev_idx;
++        ui_val = ui_bits << ui_rev_idx;
++        ui_tmp1 = ui_val + fact;
++        ui_tmp2 = acs->ui_range - 1U;
++        ui_tmp2 += acs->ui_low;
++
++        if ((acs->ui_low <= ui_val) && (ui_tmp1 <= ui_tmp2))
++            break;
++    }
++
++    return 0;
++}
++
++static int ssf_ac_data(AC4DecodeContext *s, Substream *ss,
++                       SubstreamChannel *ssch)
++{
++    int ret;
++
++    ret = ac_init(s, &ssch->acs);
++    if (ret < 0)
++        return ret;
++
++    // Not sure if passing in ui_low and ui_range are the right values
++    // for the cdf_low and cdf_high parameters - but it seems to work.
++    ret = ac_decode(s, ssch->acs.ui_low, ssch->acs.ui_range, &ssch->acs);
++    if (ret < 0)
++        return ret;
++
++    return ac_decode_finish(&ssch->acs);
++}
++
++static int ssf_granule(AC4DecodeContext *s, Substream *ss,
++                       SubstreamChannel *ssch, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ssch->stride_flag = get_bits1(gb);
++    if (iframe)
++        ssch->num_bands = get_bits(gb, 3) + 12;
++
++    ssch->start_block = 0;
++    ssch->end_block = 0;
++    if (ssch->stride_flag == LONG_STRIDE && !iframe)
++        ssch->end_block = 1;
++
++    if (ssch->stride_flag == SHORT_STRIDE) {
++        ssch->end_block = 4;
++        if (iframe)
++            ssch->start_block = 1;
++    }
++
++    for (int block = ssch->start_block; block < ssch->end_block; block++) {
++        ssch->predictor_presence[block] = get_bits1(gb);
++        if (ssch->predictor_presence[block]) {
++            if (ssch->start_block == 1 && block == 1) {
++                ssch->delta[block] = 0;
++            } else {
++                ssch->delta[block] = get_bits1(gb);
++            }
++        }
++    }
++
++    ret = ssf_st_data(s, ss, ssch, iframe);
++    if (ret < 0)
++        return ret;
++
++    return ssf_ac_data(s, ss, ssch);
++}
++
++static int ssf_data(AC4DecodeContext *s, Substream *ss,
++                    uint8_t ch_id, int iframe)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    GetBitContext *gb = &s->gbc;
++    int ssf_iframe, ret;
++
++    if (iframe)
++        ssf_iframe = 1;
++    else
++        ssf_iframe = get_bits1(gb);
++
++    ret = ssf_granule(s, ss, ssch, ssf_iframe);
++    if (ret < 0)
++        return ret;
++    if (s->frame_len_base >= 1536)
++        ret = ssf_granule(s, ss, ssch, 0);
++
++    return ret;
++}
++
++static int asf_section_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memset(ssch->sect_cb, 0, sizeof(ssch->sect_cb));
++    memset(ssch->sfb_cb, 0, sizeof(ssch->sfb_cb));
++    memset(ssch->sect_start, 0, sizeof(ssch->sect_start));
++    memset(ssch->sect_end, 0, sizeof(ssch->sect_end));
++    memset(ssch->num_sec_lsf, 0, sizeof(ssch->num_sec_lsf));
++    memset(ssch->num_sec, 0, sizeof(ssch->num_sec));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int gidx;
++        int transf_length_g = get_transf_length(s, ssch, g, &gidx);
++        int sect_esc_val;
++        int n_sect_bits;
++        int k, i, max_sfb;
++
++        if (gidx <= 2) {
++            sect_esc_val = (1 << 3) - 1;
++            n_sect_bits = 3;
++        } else {
++            sect_esc_val = (1 << 5) - 1;
++            n_sect_bits = 5;
++        }
++        k = 0;
++        i = 0;
++        ssch->num_sec_lsf[g] = 0;
++        max_sfb = get_max_sfb(s, ssch, g);
++        while (k < max_sfb) {
++            int sect_len_incr;
++            int sect_len;
++
++            ssch->sect_cb[g][i] = get_bits(gb, 4);
++            if (ssch->sect_cb[g][i] > 11) {
++                av_log(s->avctx, AV_LOG_ERROR, "sect_cb[%d][%d] > 11\n", g, i);
++                return AVERROR_INVALIDDATA;
++            }
++            sect_len = 1;
++            sect_len_incr = get_bits(gb, n_sect_bits);
++            while (sect_len_incr == sect_esc_val) {
++                sect_len += sect_esc_val;
++                sect_len_incr = get_bits(gb, n_sect_bits);
++            }
++
++            sect_len += sect_len_incr;
++            av_assert2(i < FF_ARRAY_ELEMS(ssch->sect_start[g]));
++            av_assert2(i < FF_ARRAY_ELEMS(ssch->sect_end[g]));
++            ssch->sect_start[g][i] = k;
++            ssch->sect_end[g][i] = k + sect_len;
++
++            if (ssch->sect_start[g][i] < num_sfb_48(transf_length_g) &&
++                ssch->sect_end[g][i] >= num_sfb_48(transf_length_g)) {
++                ssch->num_sec_lsf[g] = i + 1;
++                if (ssch->sect_end[g][i] > num_sfb_48(transf_length_g)) {
++                    ssch->sect_end[g][i] = num_sfb_48(transf_length_g);
++                    i++;
++                    ssch->sect_start[g][i] = num_sfb_48(transf_length_g);
++                    ssch->sect_end[g][i] = k + sect_len;
++                    ssch->sect_cb[g][i] = ssch->sect_cb[g][i-1];
++                }
++            }
++
++            if (k + sect_len >= FF_ARRAY_ELEMS(ssch->sfb_cb[0])) {
++                av_log(s->avctx, AV_LOG_ERROR, "k + sect_len overflow\n");
++                return AVERROR_INVALIDDATA;
++            }
++
++            for (int sfb = k; sfb < k + sect_len; sfb++)
++                ssch->sfb_cb[g][sfb] = ssch->sect_cb[g][i];
++            k += sect_len;
++            i++;
++        }
++
++        ssch->num_sec[g] = i;
++        if (ssch->num_sec_lsf[g] == 0)
++            ssch->num_sec_lsf[g] = ssch->num_sec[g];
++    }
++
++    return 0;
++}
++
++static int ext_decode(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int N_ext = get_unary(gb, 0, 17);
++
++    return (1 << (N_ext + 4)) + get_bits_long(gb, N_ext + 4);
++}
++
++static int asf_spectral_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memset(ssch->max_quant_idx, 0, sizeof(ssch->max_quant_idx));
++    memset(ssch->quant_spec, 0, sizeof(ssch->quant_spec));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        for (int i = 0; i < ssch->num_sec_lsf[g]; i++) {
++            int sect_start_line, sect_end_line, cb;
++
++            if (ssch->sect_cb[g][i] == 0 || ssch->sect_cb[g][i] > 11) {
++                if (ssch->sect_cb[g][i])
++                    av_log(s->avctx, AV_LOG_DEBUG, "invalid codebook %d\n", ssch->sect_cb[g][i]);
++                continue;
++            }
++
++            sect_start_line = ssch->sect_sfb_offset[g][ssch->sect_start[g][i]];
++            sect_end_line = ssch->sect_sfb_offset[g][ssch->sect_end[g][i]];
++            cb = ssch->sect_cb[g][i] - 1;
++
++            for (int k = sect_start_line; k < sect_end_line;) {
++                int cb_off = asf_codebook_off[cb];
++                int cb_mod = asf_codebook_mod[cb];
++                int x, y = g;
++
++                if (asf_codebook_dim[cb] == 4) {
++                    int cb_idx = get_vlc2(gb, asf_codebook_vlc[cb].table,
++                                          asf_codebook_vlc[cb].bits, 3);
++                    int cb_mod2 = 9;
++                    int cb_mod3 = 27;
++
++                    if (cb_idx < 0)
++                        return AVERROR_INVALIDDATA;
++
++                    av_assert2(k < FF_ARRAY_ELEMS(ssch->quant_spec));
++
++                    ssch->quant_spec[k]   = (cb_idx / cb_mod3) - cb_off;
++                    cb_idx -= (ssch->quant_spec[k]   + cb_off) * cb_mod3;
++                    ssch->quant_spec[k+1] = (cb_idx / cb_mod2) - cb_off;
++                    cb_idx -= (ssch->quant_spec[k+1] + cb_off) * cb_mod2;
++                    ssch->quant_spec[k+2] = (cb_idx / cb_mod)  - cb_off;
++                    cb_idx -= (ssch->quant_spec[k+2] + cb_off) * cb_mod;
++                    ssch->quant_spec[k+3] = cb_idx - cb_off;
++
++                    if (asf_codebook_unsigned[cb]) {
++                        if (ssch->quant_spec[k+0] && get_bits1(gb))
++                            ssch->quant_spec[k+0] = -ssch->quant_spec[k];
++                        if (ssch->quant_spec[k+1] && get_bits1(gb))
++                            ssch->quant_spec[k+1] = -ssch->quant_spec[k+1];
++                        if (ssch->quant_spec[k+2] && get_bits1(gb))
++                            ssch->quant_spec[k+2] = -ssch->quant_spec[k+2];
++                        if (ssch->quant_spec[k+3] && get_bits1(gb))
++                            ssch->quant_spec[k+3] = -ssch->quant_spec[k+3];
++                    }
++                    x = ssch->offset2sfb[k];
++                    av_assert2(x < FF_ARRAY_ELEMS(ssch->max_quant_idx[y]));
++                    ssch->max_quant_idx[y][x] = FFMAX(ssch->max_quant_idx[y][x], FFABS(ssch->quant_spec[k]));
++                    x = ssch->offset2sfb[k+1];
++                    ssch->max_quant_idx[y][x] = FFMAX(ssch->max_quant_idx[y][x], FFABS(ssch->quant_spec[k+1]));
++                    x = ssch->offset2sfb[k+2];
++                    ssch->max_quant_idx[y][x] = FFMAX(ssch->max_quant_idx[y][x], FFABS(ssch->quant_spec[k+2]));
++                    x = ssch->offset2sfb[k+3];
++                    ssch->max_quant_idx[y][x] = FFMAX(ssch->max_quant_idx[y][x], FFABS(ssch->quant_spec[k+3]));
++                    k += 4;
++                } else { /* (asf_codebook_dim[ssch->sect_cb[g][i]] == 2) */
++                    int cb_idx = get_vlc2(gb, asf_codebook_vlc[cb].table,
++                                          asf_codebook_vlc[cb].bits, 3);
++                    int sign0 = 0, sign1 = 0;
++
++                    if (cb_idx < 0)
++                        return AVERROR_INVALIDDATA;
++
++                    av_assert2(k < FF_ARRAY_ELEMS(ssch->quant_spec));
++
++                    ssch->quant_spec[k]  = (cb_idx / cb_mod) - cb_off;
++                    cb_idx -= (ssch->quant_spec[k] + cb_off) * cb_mod;
++                    ssch->quant_spec[k+1] = cb_idx - cb_off;
++
++                    if (asf_codebook_unsigned[cb]) {
++                        if (ssch->quant_spec[k] && get_bits1(gb))
++                            sign0 = 1;
++                        if (ssch->quant_spec[k+1] && get_bits1(gb))
++                            sign1 = 1;
++                    }
++
++                    if (ssch->sect_cb[g][i] == 11) {
++                        if (ssch->quant_spec[k] == 16)
++                            ssch->quant_spec[k] = ext_decode(s);
++                        if (ssch->quant_spec[k+1] == 16)
++                            ssch->quant_spec[k+1] = ext_decode(s);
++                    }
++
++                    if (sign0)
++                        ssch->quant_spec[k] = -ssch->quant_spec[k];
++                    if (sign1)
++                        ssch->quant_spec[k+1] = -ssch->quant_spec[k+1];
++
++                    x = ssch->offset2sfb[k];
++                    ssch->max_quant_idx[y][x] = FFMAX(ssch->max_quant_idx[y][x], FFABS(ssch->quant_spec[k]));
++                    x = ssch->offset2sfb[k+1];
++                    ssch->max_quant_idx[y][x] = FFMAX(ssch->max_quant_idx[y][x], FFABS(ssch->quant_spec[k+1]));
++                    k += 2;
++                }
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int asf_scalefac_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++    int first_scf_found = 0;
++    int scale_factor;
++
++    scale_factor = get_bits(gb, 8);
++    memset(ssch->sf_gain, 0, sizeof(ssch->sf_gain));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int max_sfb = FFMIN(get_max_sfb(s, ssch, g), num_sfb_48(get_transf_length(s, ssch, g, NULL)));
++
++        for (int sfb = 0; sfb < max_sfb; sfb++) {
++            if ((ssch->sfb_cb[g][sfb]) != 0 && (ssch->max_quant_idx[g][sfb] > 0)) {
++                if (first_scf_found == 1) {
++                    ssch->dpcm_sf[g][sfb] = get_vlc2(gb, scale_factors_vlc.table,
++                                                     scale_factors_vlc.bits, 3);
++                    if (ssch->dpcm_sf[g][sfb] < 0)
++                        return AVERROR_INVALIDDATA;
++                    scale_factor += ssch->dpcm_sf[g][sfb] - 60;
++                } else {
++                    first_scf_found = 1;
++                }
++
++                if (scale_factor < 0 || scale_factor > 255)
++                    return AVERROR_INVALIDDATA;
++                ssch->sf_gain[g][sfb] = powf(2.f, (scale_factor - 100) / 4.f);
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int asf_snf_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssch->snf_data_exists = get_bits1(gb);
++    if (ssch->snf_data_exists) {
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int transf_length_g = get_transf_length(s, ssch, g, NULL);
++            int max_sfb = FFMIN(get_max_sfb(s, ssch, g), num_sfb_48(transf_length_g));
++
++            for (int sfb = 0; sfb < max_sfb; sfb++) {
++                if ((ssch->sfb_cb[g][sfb] == 0) || (ssch->max_quant_idx[g][sfb] == 0)) {
++                    ssch->dpcm_snf[g][sfb] = get_vlc2(gb, snf_vlc.table, snf_vlc.bits, 3);
++                    if (ssch->dpcm_snf[g][sfb] < 0)
++                        return AVERROR_INVALIDDATA;
++                    ssch->dpcm_snf[g][sfb] -= 17;
++                }
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int sf_data(AC4DecodeContext *s, Substream *ss, int ch_id,
++                   int iframe, int spec_frontend)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    int ret;
++
++    av_log(s->avctx, AV_LOG_DEBUG, "sf_data: channel %d\n", ch_id);
++    av_log(s->avctx, AV_LOG_DEBUG, "spec_frontend: %d\n", spec_frontend);
++    if (spec_frontend == SF_ASF) {
++        ret = asf_section_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++        ret = asf_spectral_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++        ret = asf_scalefac_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++        ret = asf_snf_data(s, ss, ssch);
++    } else {
++        ret = ssf_data(s, ss, ch_id, iframe);
++    }
++
++    return ret;
++}
++
++static int chparam_info(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ssch->sap_mode = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "sap_mode: %d\n", ssch->sap_mode);
++
++    if (ssch->sap_mode == 1) {
++        av_assert2(ssch->scp.num_window_groups <= FF_ARRAY_ELEMS(ssch->ms_used));
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int max_sfb_g = get_max_sfb(s, ssch, g);
++
++            av_assert2(max_sfb_g <= FF_ARRAY_ELEMS(ssch->ms_used[0]));
++            for (int sfb = 0; sfb < max_sfb_g; sfb++) {
++                ssch->ms_used[g][sfb] = get_bits1(gb);
++            }
++        }
++    }
++
++    if (ssch->sap_mode == 3) {
++        ret = sap_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int stereo_data(AC4DecodeContext *s, Substream *ss, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ss->mdct_stereo_proc[0] = get_bits1(gb);
++    if (ss->mdct_stereo_proc[0]) {
++        ss->spec_frontend_l = SF_ASF;
++        ss->spec_frontend_r = SF_ASF;
++        ret = sf_info(s, ss, 0, SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++
++        memcpy(&ss->ssch[1].scp, &ss->ssch[0].scp, sizeof(ss->ssch[0].scp));
++        memcpy(&ss->ssch[1].sect_sfb_offset, &ss->ssch[0].sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++        memcpy(&ss->ssch[1].offset2sfb, &ss->ssch[0].offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++        memcpy(&ss->ssch[1].offset2g, &ss->ssch[0].offset2g, sizeof(ss->ssch[0].offset2g));
++        memcpy(&ss->ssch[1].win_offset, &ss->ssch[0].win_offset, sizeof(ss->ssch[0].win_offset));
++
++        ret = chparam_info(s, ss, 0);
++        if (ret < 0)
++            return ret;
++    } else {
++        ss->spec_frontend_l = get_bits1(gb);
++        sf_info(s, ss, 0, ss->spec_frontend_l, 0, 0);
++        ss->spec_frontend_r = get_bits1(gb);
++        sf_info(s, ss, 1, ss->spec_frontend_r, 0, 0);
++    }
++
++    ret = sf_data(s, ss, 0, iframe, ss->spec_frontend_l);
++    if (ret < 0)
++        return ret;
++    ret = sf_data(s, ss, 1, iframe, ss->spec_frontend_r);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int companding_control(AC4DecodeContext *s, Substream *ss, int num_chan)
++{
++    GetBitContext *gb = &s->gbc;
++    int need_avg = 0;
++    int nc;
++
++    ss->sync_flag = 0;
++    if (num_chan > 1)
++        ss->sync_flag = get_bits1(gb);
++
++    nc = ss->sync_flag ? 1 : num_chan;
++
++    for (int i = 0; i < nc; i++) {
++        ss->compand_on[i] = get_bits1(gb);
++        if (!ss->compand_on[i])
++            need_avg = 1;
++    }
++
++    if (need_avg == 1)
++        ss->compand_avg = get_bits1(gb);
++
++    return 0;
++}
++
++static int noise_mid_border(int aspx_tsg_ptr, int aspx_int_class, int num_atsg_sig)
++{
++    if (aspx_tsg_ptr == -1) {
++        if (aspx_int_class == VARFIX)
++            return 1;
++        else if (aspx_int_class != FIXFIX)
++            return num_atsg_sig - 1;
++        else
++            av_assert0(0);
++    } else if (aspx_tsg_ptr >= 0) {
++        if (aspx_int_class == VARFIX)
++            return num_atsg_sig - 1;
++        else if (aspx_int_class != FIXFIX)
++            return FFMAX(1, FFMIN(num_atsg_sig - 1, aspx_tsg_ptr));
++        else
++            av_assert0(0);
++    } else {
++        av_assert0(0);
++    }
++
++    return 0;
++}
++
++static int freq_res(uint8_t *atsg_sig, int atsg, int aspx_tsg_ptr,
++                    int num_aspx_timeslots, int aspx_freq_res_mode,
++                    const uint8_t *aspx_freq_res)
++{
++    int freq_res;
++
++    switch (aspx_freq_res_mode) {
++    case 0:
++        freq_res = aspx_freq_res[atsg];
++        break;
++    case 1:
++        freq_res = 0;
++        break;
++    case 2:
++        if ((atsg < aspx_tsg_ptr && num_aspx_timeslots > 8) ||
++            (atsg_sig[atsg+1]-atsg_sig[atsg]) > (num_aspx_timeslots/6.0+3.25))
++            freq_res = 1;
++        else
++            freq_res = 0;
++        break;
++    case 3:
++        freq_res = 1;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    return freq_res;
++}
++
++static void get_tab_border(uint8_t *atsg_sig, int num_aspx_timeslots, int num_atsg)
++{
++    const size_t size = sizeof(tab_border[0][0]);
++
++    switch (num_aspx_timeslots) {
++    case 6:
++        memcpy(atsg_sig, tab_border[0][num_atsg >> 1], size);
++        break;
++    case 8:
++        memcpy(atsg_sig, tab_border[1][num_atsg >> 1], size);
++        break;
++    case 12:
++        memcpy(atsg_sig, tab_border[2][num_atsg >> 1], size);
++        break;
++    case 15:
++        memcpy(atsg_sig, tab_border[3][num_atsg >> 1], size);
++        break;
++    case 16:
++        memcpy(atsg_sig, tab_border[4][num_atsg >> 1], size);
++        break;
++    default:
++        av_assert0(0);
++    }
++}
++
++static int aspx_atsg(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch, int iframe)
++{
++    int num_atsg_sig, num_atsg_noise;
++
++    memset(ssch->atsg_freqres, 0, sizeof(ssch->atsg_freqres));
++    memset(ssch->atsg_sig, 0, sizeof(ssch->atsg_sig));
++
++    ssch->num_atsg_sig_prev = ssch->num_atsg_sig;
++    ssch->num_atsg_noise_prev = ssch->num_atsg_noise;
++
++    num_atsg_sig = ssch->num_atsg_sig = ssch->aspx_num_env;
++    num_atsg_noise = ssch->num_atsg_noise = ssch->aspx_num_noise;
++    if (ssch->num_atsg_sig_prev == 0)
++        ssch->num_atsg_sig_prev = ssch->num_atsg_sig;
++
++    if (ssch->previous_stop_pos == 0)
++        ssch->previous_stop_pos = s->num_aspx_timeslots;
++
++    if (ssch->aspx_int_class == FIXFIX) {
++        get_tab_border(ssch->atsg_sig, s->num_aspx_timeslots, num_atsg_sig);
++        get_tab_border(ssch->atsg_noise, s->num_aspx_timeslots, num_atsg_noise);
++        ssch->atsg_freqres[0] = freq_res(ssch->atsg_sig, 0, 0, s->num_aspx_timeslots,
++                                         ss->aspx_freq_res_mode, ssch->aspx_freq_res);
++        for (int atsg = 1; atsg < num_atsg_sig; atsg++)
++            ssch->atsg_freqres[atsg] = ssch->atsg_freqres[0];
++    } else {
++        switch (ssch->aspx_int_class) {
++        case FIXVAR:
++            ssch->atsg_sig[0] = 0;
++            ssch->atsg_sig[num_atsg_sig] = ssch->aspx_var_bord_right + s->num_aspx_timeslots;
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_right; tsg++)
++                ssch->atsg_sig[num_atsg_sig-tsg-1] = ssch->atsg_sig[num_atsg_sig-tsg] - ssch->aspx_rel_bord_right[tsg];
++            break;
++        case VARFIX:
++            if (iframe)
++                ssch->atsg_sig[0] = ssch->aspx_var_bord_left;
++            else
++                ssch->atsg_sig[0] = ssch->previous_stop_pos - s->num_aspx_timeslots;
++            ssch->atsg_sig[num_atsg_sig] = s->num_aspx_timeslots;
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_left; tsg++)
++                ssch->atsg_sig[tsg+1] = ssch->atsg_sig[tsg] + ssch->aspx_rel_bord_left[tsg];
++            break;
++        case VARVAR:
++            if (iframe)
++                ssch->atsg_sig[0] = ssch->aspx_var_bord_left;
++            else
++                ssch->atsg_sig[0] = ssch->previous_stop_pos - s->num_aspx_timeslots;
++            ssch->atsg_sig[num_atsg_sig] = ssch->aspx_var_bord_right + s->num_aspx_timeslots;
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_left; tsg++)
++                ssch->atsg_sig[tsg+1] = ssch->atsg_sig[tsg] + ssch->aspx_rel_bord_left[tsg];
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_right; tsg++)
++                ssch->atsg_sig[num_atsg_sig-tsg-1] = ssch->atsg_sig[num_atsg_sig-tsg] - ssch->aspx_rel_bord_right[tsg];
++            break;
++        }
++
++        ssch->atsg_noise[0] = ssch->atsg_sig[0];
++        ssch->atsg_noise[num_atsg_noise] = ssch->atsg_sig[num_atsg_sig];
++        if (num_atsg_noise > 1)
++            ssch->atsg_noise[1] = ssch->atsg_sig[noise_mid_border(ssch->aspx_tsg_ptr,
++                                                                  ssch->aspx_int_class,
++                                                                  num_atsg_sig)];
++        for (int atsg = 0; atsg < num_atsg_sig; atsg++)
++            ssch->atsg_freqres[atsg] = freq_res(ssch->atsg_sig, atsg, ssch->aspx_tsg_ptr,
++                                                s->num_aspx_timeslots, ss->aspx_freq_res_mode,
++                                                ssch->aspx_freq_res);
++    }
++
++    ssch->previous_stop_pos = ssch->atsg_sig[num_atsg_sig];
++
++    for (int atsg = 0; atsg < num_atsg_sig; atsg++) {
++        av_log(s->avctx, AV_LOG_DEBUG, "atsg_sig[%d]: %d\n", atsg, ssch->atsg_sig[atsg]);
++
++        if (ssch->atsg_freqres[atsg]) {
++            ssch->num_sbg_sig[atsg] = ssch->num_sbg_sig_highres;
++            memcpy(ssch->sbg_sig[atsg], ssch->sbg_sig_highres, sizeof(ssch->sbg_sig_highres));
++        } else {
++            ssch->num_sbg_sig[atsg] = ssch->num_sbg_sig_lowres;
++            memcpy(ssch->sbg_sig[atsg], ssch->sbg_sig_lowres, sizeof(ssch->sbg_sig_lowres));
++        }
++    }
++    ssch->atsg_sig[num_atsg_sig] = FFMIN(s->num_aspx_timeslots, ssch->atsg_sig[num_atsg_sig]);
++    av_log(s->avctx, AV_LOG_DEBUG, "atsg_sig[%d]: %d\n", num_atsg_sig, ssch->atsg_sig[num_atsg_sig]);
++
++    return 0;
++}
++
++static int aspx_framing(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch, const int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssch->aspx_num_rel_left = 0;
++    ssch->aspx_num_rel_right = 0;
++
++    memset(ssch->aspx_freq_res, 0, sizeof(ssch->aspx_freq_res));
++
++    ssch->aspx_int_class = get_vlc2(gb, aspx_int_class_vlc.table,
++                                    aspx_int_class_vlc.bits, 3);
++    if (ssch->aspx_int_class < 0)
++        return AVERROR_INVALIDDATA;
++
++    switch (ssch->aspx_int_class) {
++    case FIXFIX:
++        ssch->aspx_num_env = 1 << get_bits(gb, 1 + ss->aspx_num_env_bits_fixfix);
++        if (ssch->aspx_num_env > 4) {
++            av_log(s->avctx, AV_LOG_ERROR, "invalid aspx num env in FIXFIX: %d\n", ssch->aspx_num_env);
++            return AVERROR_INVALIDDATA;
++        }
++
++        if (ss->aspx_freq_res_mode == 0)
++            ssch->aspx_freq_res[0] = get_bits1(gb);
++        break;
++    case FIXVAR:
++        ssch->aspx_var_bord_right = get_bits(gb, 2);
++        ssch->aspx_num_rel_right = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_right; i++)
++            ssch->aspx_rel_bord_right[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        break;
++    case VARVAR:
++        if (iframe)
++            ssch->aspx_var_bord_left = get_bits(gb, 2);
++        ssch->aspx_num_rel_left = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_left; i++)
++            ssch->aspx_rel_bord_left[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        ssch->aspx_var_bord_right = get_bits(gb, 2);
++        ssch->aspx_num_rel_right = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_right; i++)
++            ssch->aspx_rel_bord_right[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        break;
++    case VARFIX:
++        if (iframe)
++            ssch->aspx_var_bord_left = get_bits(gb, 2);
++        ssch->aspx_num_rel_left = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_left; i++)
++            ssch->aspx_rel_bord_left[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        break;
++    }
++
++    if (ssch->aspx_int_class != FIXFIX) {
++        int ptr_bits;
++
++        ssch->aspx_num_env = ssch->aspx_num_rel_left + ssch->aspx_num_rel_right + 1;
++        if (ssch->aspx_num_env > 5) {
++            av_log(s->avctx, AV_LOG_ERROR, "invalid aspx num env: %d (class %d)\n", ssch->aspx_num_env, ssch->aspx_int_class);
++            return AVERROR_INVALIDDATA;
++        }
++
++        ptr_bits = ceilf(logf(ssch->aspx_num_env + 2) / logf(2));
++        av_assert2(ptr_bits > 0);
++        ssch->aspx_tsg_ptr_prev = ssch->aspx_tsg_ptr;
++        ssch->aspx_tsg_ptr = get_bits(gb, ptr_bits);
++        ssch->aspx_tsg_ptr -= 1;
++        if (ss->aspx_freq_res_mode == 0)
++            for (int env = 0; env < ssch->aspx_num_env; env++)
++                ssch->aspx_freq_res[env] = get_bits1(gb);
++    }
++
++    if (ssch->aspx_num_env > 1)
++        ssch->aspx_num_noise = 2;
++    else
++        ssch->aspx_num_noise = 1;
++
++    av_log(s->avctx, AV_LOG_DEBUG, "aspx_num_sig: %d\n", ssch->aspx_num_env);
++    av_log(s->avctx, AV_LOG_DEBUG, "aspx_num_noise: %d\n", ssch->aspx_num_noise);
++
++    return aspx_atsg(s, ss, ssch, iframe);
++}
++
++static void aspx_delta_dir(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    av_assert2(ssch->aspx_num_env <= FF_ARRAY_ELEMS(ssch->aspx_sig_delta_dir));
++    for (int env = 0; env < ssch->aspx_num_env; env++)
++        ssch->aspx_sig_delta_dir[env] = get_bits1(gb);
++
++    av_assert2(ssch->aspx_num_noise <= FF_ARRAY_ELEMS(ssch->aspx_noise_delta_dir));
++    for (int env = 0; env < ssch->aspx_num_noise; env++)
++        ssch->aspx_noise_delta_dir[env] = get_bits1(gb);
++}
++
++static int aspx_hfgen_iwc_2ch(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch0,
++                              SubstreamChannel *ssch1,
++                              int aspx_balance)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memcpy(ssch0->aspx_tna_mode_prev, ssch0->aspx_tna_mode, sizeof(ssch0->aspx_tna_mode));
++    memcpy(ssch1->aspx_tna_mode_prev, ssch1->aspx_tna_mode, sizeof(ssch1->aspx_tna_mode));
++    memset(ssch0->aspx_tna_mode, 0, sizeof(ssch0->aspx_tna_mode));
++    memset(ssch1->aspx_tna_mode, 0, sizeof(ssch1->aspx_tna_mode));
++    memset(ssch0->aspx_fic_used_in_sfb, 0, sizeof(ssch0->aspx_fic_used_in_sfb));
++    memset(ssch1->aspx_fic_used_in_sfb, 0, sizeof(ssch1->aspx_fic_used_in_sfb));
++    memset(ssch0->aspx_tic_used_in_slot, 0, sizeof(ssch0->aspx_tic_used_in_slot));
++    memset(ssch1->aspx_tic_used_in_slot, 0, sizeof(ssch1->aspx_tic_used_in_slot));
++
++    av_assert2(ssch0->num_sbg_noise <= FF_ARRAY_ELEMS(ssch0->aspx_tna_mode));
++    av_assert2(ssch1->num_sbg_noise <= FF_ARRAY_ELEMS(ssch1->aspx_tna_mode));
++
++    for (int n = 0; n < ssch0->num_sbg_noise; n++)
++        ssch0->aspx_tna_mode[n] = get_bits(gb, 2);
++    if (aspx_balance == 0) {
++        for (int n = 0; n < ssch0->num_sbg_noise; n++)
++            ssch1->aspx_tna_mode[n] = get_bits(gb, 2);
++    } else {
++        for (int n = 0; n < ssch0->num_sbg_noise; n++)
++            ssch1->aspx_tna_mode[n] = ssch0->aspx_tna_mode[n];
++    }
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++            ssch0->aspx_add_harmonic[n] = get_bits1(gb);
++    }
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++            ssch1->aspx_add_harmonic[n] = get_bits1(gb);
++    }
++
++    if (get_bits1(gb)) {
++        if (get_bits1(gb)) {
++            for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++                ssch0->aspx_fic_used_in_sfb[n] = get_bits1(gb);
++        }
++
++        if (get_bits1(gb)) {
++            for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++                ssch1->aspx_fic_used_in_sfb[n] = get_bits1(gb);
++        }
++    }
++
++    if (get_bits1(gb)) {
++        int aspx_tic_copy = get_bits1(gb);
++        int aspx_tic_left = 0, aspx_tic_right = 0;
++
++        if (aspx_tic_copy == 0) {
++            aspx_tic_left = get_bits1(gb);
++            aspx_tic_right = get_bits1(gb);
++        }
++
++        if (aspx_tic_copy || aspx_tic_left) {
++            for (int n = 0; n < s->num_aspx_timeslots; n++)
++                ssch0->aspx_tic_used_in_slot[n] = get_bits1(gb);
++        }
++
++        if (aspx_tic_right) {
++            for (int n = 0; n < s->num_aspx_timeslots; n++)
++                ssch1->aspx_tic_used_in_slot[n] = get_bits1(gb);
++        }
++
++        if (aspx_tic_copy) {
++            for (int n = 0; n < s->num_aspx_timeslots; n++)
++                ssch1->aspx_tic_used_in_slot[n] = ssch0->aspx_tic_used_in_slot[n];
++        }
++    }
++
++    return 0;
++}
++
++static VLC *get_aspx_hcb(int data_type, int quant_mode, int stereo_mode, int hcb_type)
++{
++    VLC *aspx_cb;
++
++    if (data_type == DT_SIGNAL)
++        aspx_cb = &aspx_codebook_signal_vlc[stereo_mode][quant_mode][hcb_type];
++    else // NOISE
++        aspx_cb = &aspx_codebook_noise_vlc[stereo_mode][hcb_type];
++
++    return aspx_cb;
++}
++
++static int get_aspx_off(int data_type, int quant_mode, int stereo_mode)
++{
++    int off;
++
++    if (data_type == DT_SIGNAL)
++        off = aspx_codebook_signal_off[stereo_mode][quant_mode];
++    else // NOISE
++        off = aspx_codebook_noise_off[stereo_mode];
++
++    return off;
++}
++
++static int aspx_huff_data(AC4DecodeContext *s,
++                          int data_type, int num_sbg,
++                          int quant_mode, int stereo_mode,
++                          int direction, int16_t *data)
++{
++    GetBitContext *gb = &s->gbc;
++    VLC *aspx_cb;
++    int aspx_off;
++
++    if (direction == 0) { // FREQ
++        aspx_cb = get_aspx_hcb(data_type, quant_mode, stereo_mode, F0);
++        data[0] = get_vlc2(gb, aspx_cb->table, aspx_cb->bits, 3);
++        if (data[0] < 0)
++            return AVERROR_INVALIDDATA;
++        aspx_cb = get_aspx_hcb(data_type, quant_mode, stereo_mode, DF);
++        aspx_off = get_aspx_off(data_type, quant_mode, stereo_mode);
++        for (int i = 1; i < num_sbg; i++) {
++            data[i] = get_vlc2(gb, aspx_cb->table, aspx_cb->bits, 3);
++            if (data[i] < 0)
++                return AVERROR_INVALIDDATA;
++            data[i] -= aspx_off;
++        }
++    } else { // TIME
++        aspx_cb = get_aspx_hcb(data_type, quant_mode, stereo_mode, DT);
++        aspx_off = get_aspx_off(data_type, quant_mode, stereo_mode);
++        for (int i = 0; i < num_sbg; i++) {
++            data[i] = get_vlc2(gb, aspx_cb->table, aspx_cb->bits, 3);
++            if (data[i] < 0)
++                return AVERROR_INVALIDDATA;
++            data[i] -= aspx_off;
++        }
++    }
++
++    return 0;
++}
++
++static int aspx_ec_data(AC4DecodeContext *s,
++                        Substream *ss,
++                        SubstreamChannel *ssch,
++                        int data_type, int num_env,
++                        uint8_t *freq_res, int quant_mode,
++                        int stereo_mode, uint8_t *direction)
++{
++    int dir, num_sbg, ret;
++
++    for (int env = 0; env < num_env; env++) {
++        if (data_type == DT_SIGNAL) {
++            if (freq_res[env])
++                num_sbg = ssch->num_sbg_sig_highres;
++            else
++                num_sbg = ssch->num_sbg_sig_lowres;
++        } else {
++            num_sbg = ssch->num_sbg_noise;
++        }
++        dir = direction[env];
++        av_assert2(num_sbg <= FF_ARRAY_ELEMS(ssch->aspx_data[data_type][env]));
++        ret = aspx_huff_data(s, data_type, num_sbg, quant_mode, stereo_mode, dir,
++                             ssch->aspx_data[data_type][env]);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int is_element_of_sbg_patches(int sbg_lim_sbg, int *sbg_patches,
++                                     int num_sbg_patches)
++{
++    for (int i = 0; i <= num_sbg_patches; i++) {
++        if (sbg_patches[i] == sbg_lim_sbg)
++            return 1;
++    }
++
++    return 0;
++}
++
++static void remove_element(int *sbg_lim, int num_sbg_lim, int sbg)
++{
++    for (int i = sbg; i < num_sbg_lim; i++)
++        sbg_lim[i] = sbg_lim[i + 1];
++}
++
++static int cmpints(const void *p1, const void *p2)
++{
++    int left  = *(const int *)p1;
++    int right = *(const int *)p2;
++    return FFDIFFSIGN(left, right);
++}
++
++static int aspx_elements(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch,
++                         const int iframe)
++{
++    int sb, j, sbg = 0, goal_sb, msb, usb;
++    int source_band_low, prev_idx;
++
++    ssch->master_reset = 0;
++    if (iframe) {
++        ssch->master_reset = !!(s->first_frame +
++                                (ss->prev_aspx_start_freq != ss->aspx_start_freq) +
++                                (ss->prev_aspx_stop_freq != ss->aspx_stop_freq) +
++                                (ss->prev_aspx_master_freq_scale != ss->aspx_master_freq_scale));
++    }
++
++    if (ssch->master_reset) {
++        if (ss->aspx_master_freq_scale == 1) {
++            ssch->num_sbg_master = 22 - 2 * ss->aspx_start_freq - 2 * ss->aspx_stop_freq;
++            for (int sbg = 0; sbg <= ssch->num_sbg_master; sbg++) {
++                ssch->sbg_master[sbg] = sbg_template_highres[2 * ss->aspx_start_freq + sbg];
++            }
++        } else {
++            ssch->num_sbg_master = 20 - 2 * ss->aspx_start_freq - 2 * ss->aspx_stop_freq;
++            for (int sbg = 0; sbg <= ssch->num_sbg_master; sbg++) {
++                ssch->sbg_master[sbg] = sbg_template_lowres[2 * ss->aspx_start_freq + sbg];
++            }
++        }
++    }
++
++    av_log(s->avctx, AV_LOG_DEBUG, "num_sbg_master: %d\n", ssch->num_sbg_master);
++
++    ssch->sba = ssch->sbg_master[0];
++    ssch->sbz = ssch->sbg_master[ssch->num_sbg_master];
++
++    ssch->num_sbg_sig_highres = ssch->num_sbg_master - ssch->aspx_xover_subband_offset;
++    av_log(s->avctx, AV_LOG_DEBUG, "num_sbg_sig_highres: %d\n", ssch->num_sbg_sig_highres);
++    for (int sbg = 0; sbg <= ssch->num_sbg_sig_highres; sbg++)
++        ssch->sbg_sig_highres[sbg] = ssch->sbg_master[sbg + ssch->aspx_xover_subband_offset];
++
++    ssch->sbx = ssch->sbg_sig_highres[0];
++    av_log(s->avctx, AV_LOG_DEBUG, "sbx: %d\n", ssch->sbx);
++    if (ssch->sbx <= 0)
++        return AVERROR_INVALIDDATA;
++    ssch->num_sb_aspx = ssch->sbg_sig_highres[ssch->num_sbg_sig_highres] - ssch->sbx;
++
++    ssch->num_sbg_sig_lowres = ssch->num_sbg_sig_highres - floorf(ssch->num_sbg_sig_highres / 2.f);
++    av_log(s->avctx, AV_LOG_DEBUG, "num_sbg_sig_lowres: %d\n", ssch->num_sbg_sig_lowres);
++
++    ssch->sbg_sig_lowres[0] = ssch->sbg_sig_highres[0];
++    if ((ssch->num_sbg_sig_highres & 1) == 0) {
++        av_assert2(ssch->num_sbg_sig_lowres < FF_ARRAY_ELEMS(ssch->sbg_sig_lowres));
++        av_assert2(ssch->num_sbg_sig_lowres * 2 < FF_ARRAY_ELEMS(ssch->sbg_sig_highres));
++        for (int sbg = 1; sbg <= ssch->num_sbg_sig_lowres; sbg++)
++            ssch->sbg_sig_lowres[sbg] = ssch->sbg_sig_highres[2*sbg];
++    } else {
++        av_assert2(ssch->num_sbg_sig_lowres < FF_ARRAY_ELEMS(ssch->sbg_sig_lowres));
++        av_assert2(ssch->num_sbg_sig_lowres * 2 < FF_ARRAY_ELEMS(ssch->sbg_sig_highres));
++        for (int sbg = 1; sbg <= ssch->num_sbg_sig_lowres; sbg++)
++            ssch->sbg_sig_lowres[sbg] = ssch->sbg_sig_highres[2*sbg-1];
++    }
++
++    ssch->num_sbg_sig[0] = ssch->num_sbg_sig_lowres;
++    ssch->num_sbg_sig[1] = ssch->num_sbg_sig_highres;
++
++    ssch->num_sbg_noise = FFMAX(1, floorf(ss->aspx_noise_sbg * log2f(ssch->sbz / (float)ssch->sbx) + 0.5f));
++    if (ssch->num_sbg_noise > 5) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid num sbg noise: %d\n", ssch->num_sbg_noise);
++        return AVERROR_INVALIDDATA;
++    }
++
++    prev_idx = 0;
++    ssch->sbg_noise[0] = ssch->sbg_sig_lowres[0];
++    for (int sbg = 1; sbg <= ssch->num_sbg_noise; sbg++) {
++        int idx = prev_idx;
++
++        idx += floorf((ssch->num_sbg_sig_lowres - prev_idx) / (float)(ssch->num_sbg_noise + 1 - sbg));
++        ssch->sbg_noise[sbg] = ssch->sbg_sig_lowres[idx];
++        prev_idx = idx;
++    }
++
++    msb = ssch->sba;
++    usb = ssch->sbx;
++    ssch->num_sbg_patches = 0;
++    if (s->fs_index)
++        goal_sb = 43;
++    else
++        goal_sb = 46;
++    if (ss->aspx_master_freq_scale == 1)
++        source_band_low = 4;
++    else
++        source_band_low = 2;
++
++    if (goal_sb < ssch->sbx + ssch->num_sb_aspx) {
++        for (int i = 0; ssch->sbg_master[i] < goal_sb; i++)
++            sbg = i + 1;
++    } else {
++        sbg = ssch->num_sbg_master;
++    }
++
++    do {
++        int odd;
++
++        j = sbg;
++        sb = ssch->sbg_master[j];
++        odd = (sb - 2 + ssch->sba) % 2;
++
++        while (sb > (ssch->sba - source_band_low + msb - odd) && j >= 1) {
++            j--;
++            sb = ssch->sbg_master[j];
++            odd = (sb - 2 + ssch->sba) % 2;
++        }
++
++        ssch->sbg_patch_num_sb[ssch->num_sbg_patches] = FFMAX(sb - usb, 0);
++        ssch->sbg_patch_start_sb[ssch->num_sbg_patches] = ssch->sba - odd - FFMAX(sb - usb, 0);
++        if (ssch->sbg_patch_num_sb[ssch->num_sbg_patches] > 0) {
++            usb = sb;
++            msb = sb;
++            ssch->num_sbg_patches++;
++        } else {
++            msb = ssch->sbx;
++        }
++
++        if (ssch->sbg_master[sbg] - sb < 3)
++            sbg = ssch->num_sbg_master;
++    } while (sb != (ssch->sbx + ssch->num_sb_aspx) && j > 0);
++
++    if ((ssch->num_sbg_patches > 1) && (ssch->sbg_patch_num_sb[ssch->num_sbg_patches - 1] < 3))
++        ssch->num_sbg_patches--;
++
++    if (ssch->num_sbg_patches > 5)
++        return AVERROR_INVALIDDATA;
++
++    ssch->sbg_patches[0] = ssch->sbx;
++    for (int i = 1; i <= ssch->num_sbg_patches; i++)
++        ssch->sbg_patches[i] = ssch->sbg_patches[i-1] + ssch->sbg_patch_num_sb[i-1];
++
++    /* Copy sbg_sig_lowres into lower part of limiter table */
++    for (int sbg = 0; sbg <= ssch->num_sbg_sig_lowres; sbg++)
++        ssch->sbg_lim[sbg] = ssch->sbg_sig_lowres[sbg];
++
++    /* Copy patch borders into higher part of limiter table */
++    for (int sbg = 1; sbg < ssch->num_sbg_patches; sbg++)
++        ssch->sbg_lim[sbg + ssch->num_sbg_sig_lowres] = ssch->sbg_patches[sbg];
++
++    /* Sort patch borders + low res sbg into temporary limiter table */
++    ssch->num_sbg_lim = ssch->num_sbg_sig_lowres + ssch->num_sbg_patches - 1;
++    AV_QSORT(ssch->sbg_lim, ssch->num_sbg_lim, int, cmpints);
++    sbg = 1;
++
++    while (sbg <= ssch->num_sbg_lim) {
++        float num_octaves = log2(ssch->sbg_lim[sbg] / (float)ssch->sbg_lim[sbg - 1]);
++
++        if (num_octaves < 0.245f) {
++            if (ssch->sbg_lim[sbg] == ssch->sbg_lim[sbg-1]) {
++                remove_element(ssch->sbg_lim, ssch->num_sbg_lim, sbg);
++                ssch->num_sbg_lim--;
++                continue;
++            } else {
++                if (is_element_of_sbg_patches(ssch->sbg_lim[sbg],
++                                              ssch->sbg_patches,
++                                              ssch->num_sbg_patches)) {
++                    if (is_element_of_sbg_patches(ssch->sbg_lim[sbg - 1],
++                                                  ssch->sbg_patches,
++                                                  ssch->num_sbg_patches)) {
++                        sbg++;
++                        continue;
++                    } else {
++                        remove_element(ssch->sbg_lim, ssch->num_sbg_lim, sbg - 1);
++                        ssch->num_sbg_lim--;
++                        continue;
++                    }
++                } else {
++                    remove_element(ssch->sbg_lim, ssch->num_sbg_lim, sbg);
++                    ssch->num_sbg_lim--;
++                    continue;
++                }
++            }
++        } else {
++            sbg++;
++            continue;
++        }
++    }
++
++    return 0;
++}
++
++static int aspx_data_2ch(AC4DecodeContext *s, Substream *ss,
++                         uint8_t ch_id[2], int iframe)
++{
++    SubstreamChannel *ssch0 = &ss->ssch[ch_id[0]];
++    SubstreamChannel *ssch1 = &ss->ssch[ch_id[1]];
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    if (iframe) {
++        ssch0->aspx_xover_subband_offset = get_bits(gb, 3);
++        ssch1->aspx_xover_subband_offset = ssch0->aspx_xover_subband_offset;
++    }
++
++    ret = aspx_elements(s, ss, ssch0, iframe);
++    if (ret < 0)
++        return ret;
++
++    ret = aspx_elements(s, ss, ssch1, iframe);
++    if (ret < 0)
++        return ret;
++
++    ret = aspx_framing(s, ss, ssch0, iframe);
++    if (ret < 0)
++        return ret;
++
++    ssch0->aspx_qmode_env = ssch1->aspx_qmode_env = ss->aspx_quant_mode_env;
++    if (ssch0->aspx_int_class == FIXFIX && ssch0->aspx_num_env == 1)
++        ssch0->aspx_qmode_env = ssch1->aspx_qmode_env = 0;
++
++    ssch0->aspx_balance = ssch1->aspx_balance = get_bits1(gb);
++
++    if (ssch0->aspx_balance == 0) {
++        ret = aspx_framing(s, ss, ssch1, iframe);
++        if (ret < 0)
++            return ret;
++        ssch1->aspx_qmode_env = ss->aspx_quant_mode_env;
++        if (ssch1->aspx_int_class == FIXFIX && ssch1->aspx_num_env == 1)
++            ssch1->aspx_qmode_env = 0;
++    } else {
++        ssch1->sbx = ssch0->sbx;
++        ssch1->num_sb_aspx = ssch0->num_sb_aspx;
++        ssch1->aspx_num_env = ssch0->aspx_num_env;
++        ssch1->aspx_num_noise = ssch0->aspx_num_noise;
++        ssch1->num_atsg_sig = ssch0->num_atsg_sig;
++        ssch1->num_atsg_noise = ssch0->num_atsg_noise;
++        memcpy(ssch1->sbg_sig, ssch0->sbg_sig, sizeof(ssch0->sbg_sig));
++        memcpy(ssch1->atsg_sig, ssch0->atsg_sig, sizeof(ssch0->atsg_sig));
++        memcpy(ssch1->num_sbg_sig, ssch0->num_sbg_sig, sizeof(ssch0->num_sbg_sig));
++        memcpy(ssch1->atsg_freqres, ssch0->atsg_freqres, sizeof(ssch0->atsg_freqres));
++    }
++
++    aspx_delta_dir(s, ssch0);
++    aspx_delta_dir(s, ssch1);
++    aspx_hfgen_iwc_2ch(s, ss, ssch0, ssch1, ssch0->aspx_balance);
++
++    memset(ssch0->aspx_data, 0, sizeof(ssch0->aspx_data));
++    memset(ssch1->aspx_data, 0, sizeof(ssch1->aspx_data));
++
++    ret = aspx_ec_data(s, ss, ssch0, DT_SIGNAL,
++                       ssch0->aspx_num_env,
++                       ssch0->atsg_freqres,
++                       ssch0->aspx_qmode_env,
++                       SM_LEVEL,
++                       ssch0->aspx_sig_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch1, DT_SIGNAL,
++                       ssch1->aspx_num_env,
++                       ssch1->atsg_freqres,
++                       ssch1->aspx_qmode_env,
++                       ssch0->aspx_balance ? SM_BALANCE : SM_LEVEL,
++                       ssch1->aspx_sig_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch0, DT_NOISE,
++                       ssch0->aspx_num_noise,
++                       0,
++                       0,
++                       SM_LEVEL,
++                       ssch0->aspx_noise_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch1, DT_NOISE,
++                       ssch1->aspx_num_noise,
++                       0,
++                       0,
++                       ssch0->aspx_balance ? SM_BALANCE : SM_LEVEL,
++                       ssch1->aspx_noise_delta_dir);
++
++    return ret;
++}
++
++static int aspx_hfgen_iwc_1ch(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memcpy(ssch->aspx_tna_mode_prev, ssch->aspx_tna_mode, sizeof(ssch->aspx_tna_mode));
++    memset(ssch->aspx_tna_mode, 0, sizeof(ssch->aspx_tna_mode));
++    memset(ssch->aspx_fic_used_in_sfb, 0, sizeof(ssch->aspx_fic_used_in_sfb));
++    memset(ssch->aspx_tic_used_in_slot, 0, sizeof(ssch->aspx_tic_used_in_slot));
++
++    av_assert2(ssch->num_sbg_noise <= FF_ARRAY_ELEMS(ssch->aspx_tna_mode));
++
++    for (int n = 0; n < ssch->num_sbg_noise; n++)
++        ssch->aspx_tna_mode[n] = get_bits(gb, 2);
++
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch->num_sbg_sig_highres; n++)
++            ssch->aspx_add_harmonic[n] = get_bits1(gb);
++    }
++
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch->num_sbg_sig_highres; n++)
++            ssch->aspx_fic_used_in_sfb[n] = get_bits1(gb);
++    }
++
++    if (get_bits1(gb)) {
++        for (int n = 0; n < s->num_aspx_timeslots; n++)
++            ssch->aspx_tic_used_in_slot[n] = get_bits1(gb);
++    }
++
++    return 0;
++}
++
++static int aspx_data_1ch(AC4DecodeContext *s, Substream *ss,
++                         int ch_id, int iframe)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    if (iframe)
++        ssch->aspx_xover_subband_offset = get_bits(gb, 3);
++
++    ssch->aspx_balance = 0;
++
++    ret = aspx_elements(s, ss, ssch, iframe);
++    if (ret < 0)
++        return ret;
++
++    ret = aspx_framing(s, ss, ssch, iframe);
++    if (ret < 0)
++        return ret;
++
++    ssch->aspx_qmode_env = ss->aspx_quant_mode_env;
++    if (ssch->aspx_int_class == FIXFIX && ssch->aspx_num_env == 1)
++        ssch->aspx_qmode_env = 0;
++
++    aspx_delta_dir(s, ssch);
++    aspx_hfgen_iwc_1ch(s, ss, ssch);
++
++    memset(ssch->aspx_data, 0, sizeof(ssch->aspx_data));
++
++    ret = aspx_ec_data(s, ss, ssch, DT_SIGNAL,
++                       ssch->aspx_num_env,
++                       ssch->atsg_freqres,
++                       ssch->aspx_qmode_env,
++                       0,
++                       ssch->aspx_sig_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch, DT_NOISE,
++                       ssch->aspx_num_noise,
++                       0,
++                       0,
++                       0,
++                       ssch->aspx_noise_delta_dir);
++    return ret;
++}
++
++static int acpl_framing_data(AC4DecodeContext *s, Substream *ss,
++                             SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssch->acpl_interpolation_type = get_bits1(gb);
++    ssch->acpl_num_param_sets_cod = get_bits1(gb);
++    if (ssch->acpl_interpolation_type) {
++        for (int ps = 0; ps < ssch->acpl_num_param_sets_cod + 1; ps++)
++            ssch->acpl_param_timeslot[ps] = get_bits(gb, 5);
++    }
++
++    return 0;
++}
++
++static VLC *get_acpl_hcb(int data_type, int quant_mode, int hcb_type)
++{
++    VLC *acpl_cb;
++
++    acpl_cb = &acpl_codebook_vlc[data_type][quant_mode][hcb_type];
++
++    return acpl_cb;
++}
++
++static int get_acpl_off(int data_type, int quant_mode, int hcb_type)
++{
++    int off;
++
++    off = acpl_codebook_signal_off[data_type][quant_mode][hcb_type];
++
++    return off;
++}
++
++static int acpl_huff_data(AC4DecodeContext *s,
++                          int data_type, int data_bands,
++                          int start_band, int quant_mode,
++                          int *data)
++{
++    GetBitContext *gb = &s->gbc;
++    int diff_type;
++    VLC *acpl_cb;
++    int acpl_off;
++
++    switch (data_type) {
++    case ALPHA1:
++    case ALPHA2:
++        data_type = 0;
++        break;
++    case BETA1:
++    case BETA2:
++        data_type = 1;
++        break;
++    case BETA3:
++        data_type = 2;
++        break;
++    default:
++        data_type = 3;
++        break;
++    };
++
++    diff_type = get_bits1(gb);
++    if (diff_type == 0) { // DIFF_FREQ
++        acpl_cb = get_acpl_hcb(data_type, quant_mode, F0);
++        acpl_off = get_acpl_off(data_type, quant_mode, F0);
++        data[start_band] = get_vlc2(gb, acpl_cb->table, acpl_cb->bits, 3);
++        if (data[start_band] < 0)
++            return AVERROR_INVALIDDATA;
++        data[start_band] -= acpl_off;
++        acpl_cb = get_acpl_hcb(data_type, quant_mode, DF);
++        acpl_off = get_acpl_off(data_type, quant_mode, DF);
++        for (int i = start_band + 1; i < data_bands; i++) {
++            data[i] = get_vlc2(gb, acpl_cb->table, acpl_cb->bits, 3);
++            if (data[i] < 0)
++                return AVERROR_INVALIDDATA;
++            data[i] -= acpl_off;
++        }
++    } else { // DIFF_TIME
++        acpl_cb = get_acpl_hcb(data_type, quant_mode, DT);
++        acpl_off = get_acpl_off(data_type, quant_mode, DT);
++        for (int i = start_band; i < data_bands; i++) {
++            data[i] = get_vlc2(gb, acpl_cb->table, acpl_cb->bits, 3);
++            if (data[i] < 0)
++                return AVERROR_INVALIDDATA;
++            data[i] -= acpl_off;
++        }
++    }
++
++    return 0;
++}
++
++static int acpl_ec_data(AC4DecodeContext *s, Substream *ss,
++                        SubstreamChannel *ssch,
++                        int data_type, int data_bands,
++                        int start_band, int quant_mode)
++{
++    int ret;
++
++    for (int ps = 0; ps < ssch->acpl_num_param_sets_cod + 1; ps++) {
++        ret = acpl_huff_data(s, data_type, data_bands,
++                             start_band, quant_mode,
++                             ssch->acpl_data[data_type]);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int acpl_data_2ch(AC4DecodeContext *s, Substream *ss,
++                         SubstreamChannel *ssch0,
++                         SubstreamChannel *ssch1)
++{
++    int ret, num_bands, st;
++
++    acpl_framing_data(s, ss, ssch0);
++
++    num_bands = acpl_num_param_bands[ss->acpl_num_param_bands_id];
++    st = ss->acpl_param_band;
++
++    ret = acpl_ec_data(s, ss, ssch0, ALPHA1, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, ALPHA2, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, BETA1, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, BETA2, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, BETA3, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA1, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA2, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA3, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA4, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA5, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA6, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int acpl_data_1ch(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    int ret, num_bands, start;
++
++    acpl_framing_data(s, ss, ssch);
++
++    num_bands = acpl_num_param_bands[ss->acpl_num_param_bands_id];
++    start = ss->acpl_param_band;
++
++    ret = acpl_ec_data(s, ss, ssch, ALPHA1, num_bands, start, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++
++    ret = acpl_ec_data(s, ss, ssch, BETA1, num_bands, start, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int channel_pair_element(AC4DecodeContext *s, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int spec_frontend, ret = 0;
++
++    s->ch_map[AV_CHAN_FRONT_LEFT]  = 0;
++    s->ch_map[AV_CHAN_FRONT_RIGHT] = 1;
++
++    ss->codec_mode = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode != CM_SIMPLE)
++            aspx_config(s, ss);
++        if (ss->codec_mode == CM_ASPX_ACPL_1)
++            acpl_config_1ch(s, ss, ACPL_PARTIAL);
++        if (ss->codec_mode == CM_ASPX_ACPL_2)
++            acpl_config_1ch(s, ss, ACPL_FULL);
++    }
++
++    switch (ss->codec_mode) {
++    case CM_SIMPLE:
++        ret = stereo_data(s, ss, iframe);
++        break;
++    case CM_ASPX:
++        companding_control(s, ss, 2);
++        ret = stereo_data(s, ss, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_2ch(s, ss, (uint8_t []){0, 1}, iframe);
++        break;
++    case CM_ASPX_ACPL_1:
++        companding_control(s, ss, 1);
++        ss->mdct_stereo_proc[0] = get_bits1(gb);
++        if (ss->mdct_stereo_proc[0]) {
++            ss->spec_frontend_m = SF_ASF;
++            ss->spec_frontend_s = SF_ASF;
++            ret = sf_info(s, ss, 0, SF_ASF, 1, 0);
++            if (ret < 0)
++                return ret;
++
++            memcpy(&ss->ssch[1].scp, &ss->ssch[0].scp, sizeof(ss->ssch[0].scp));
++            memcpy(&ss->ssch[1].sect_sfb_offset, &ss->ssch[0].sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++            memcpy(&ss->ssch[1].offset2sfb, &ss->ssch[0].offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++            memcpy(&ss->ssch[1].offset2g, &ss->ssch[0].offset2g, sizeof(ss->ssch[0].offset2g));
++            memcpy(&ss->ssch[1].win_offset, &ss->ssch[0].win_offset, sizeof(ss->ssch[0].win_offset));
++
++            ret = chparam_info(s, ss, 0);
++            if (ret < 0)
++                return ret;
++        } else {
++            ss->spec_frontend_m = get_bits1(gb);
++            ret = sf_info(s, ss, 0, ss->spec_frontend_m, 0, 0);
++            if (ret < 0)
++                return ret;
++            ss->spec_frontend_s = get_bits1(gb);
++            ret = sf_info(s, ss, 1, ss->spec_frontend_s, 0, 1);
++            if (ret < 0)
++                return ret;
++        }
++        ret = sf_data(s, ss, 0, iframe, ss->spec_frontend_m);
++        if (ret < 0)
++            return ret;
++        ret = sf_data(s, ss, 1, iframe, ss->spec_frontend_m);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, 0, iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, 0);
++        break;
++    case CM_ASPX_ACPL_2:
++        companding_control(s, ss, 1);
++        spec_frontend = get_bits1(gb);
++        ret = sf_info(s, ss, 0, spec_frontend, 0, 0);
++        if (ret < 0)
++            return ret;
++        ret = sf_data(s, ss, 0, iframe, spec_frontend);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, 0, iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, 0);
++        break;
++    }
++
++    return ret;
++}
++
++static int four_channel_data(AC4DecodeContext *s, Substream *ss, int iframe, uint8_t ch_id[4])
++{
++    int ret;
++
++    ret = sf_info(s, ss, ch_id[0], SF_ASF, 0, 0);
++    if (ret < 0)
++        return ret;
++
++    for (int i = 1; i < 4; i++)
++        memcpy(&ss->ssch[ch_id[i]], &ss->ssch[ch_id[0]], sizeof(ss->ssch[0]));
++
++    for (int i = 0; i < 4; i++) {
++        ret = chparam_info(s, ss, ch_id[i]);
++        if (ret < 0)
++            return ret;
++    }
++
++    for (int i = 0; i < 4; i++) {
++        ret = sf_data(s, ss, ch_id[i], iframe, SF_ASF);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int five_channel_info(AC4DecodeContext *s, Substream *ss, uint8_t ch_id[5])
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ss->chel_matsel = get_bits(gb, 4);
++
++    for (int n = 0; n < 5; n++) {
++        ret = chparam_info(s, ss, ch_id[n]);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int five_channel_data(AC4DecodeContext *s, Substream *ss, int iframe, uint8_t ch_id[5])
++{
++    SubstreamChannel *ssch[5];
++    int ret;
++
++    for (int n = 0; n < 5; n++)
++        ssch[n] = &ss->ssch[ch_id[n]];
++
++    ret = sf_info(s, ss, ch_id[0], SF_ASF, 0, 0);
++    if (ret < 0)
++        return ret;
++
++    for (int i = 1; i < 5; i++) {
++        memcpy(&ssch[i]->scp, &ssch[0]->scp, sizeof(ss->ssch[0].scp));
++        memcpy(&ssch[i]->sect_sfb_offset, &ssch[0]->sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++        memcpy(&ssch[i]->offset2sfb, &ssch[0]->offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++        memcpy(&ssch[i]->offset2g, &ssch[0]->offset2g, sizeof(ss->ssch[0].offset2g));
++        memcpy(&ssch[i]->win_offset, &ssch[0]->win_offset, sizeof(ss->ssch[0].win_offset));
++    }
++
++    ret = five_channel_info(s, ss, ch_id);
++    if (ret < 0)
++        return ret;
++
++    for (int n = 0; n < 5; n++) {
++        ret = sf_data(s, ss, ch_id[n], iframe, SF_ASF);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int sf_info_lfe(AC4DecodeContext *s, Substream *ss,
++                        SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++    int n_msfbl_bits = get_msfbl_bits(s->frame_len_base);
++    int n_grp_bits = get_grp_bits(s, ssch);
++
++    ssch->scp.long_frame = 1;
++    ssch->scp.max_sfb[0] = get_bits(gb, n_msfbl_bits);
++    ssch->scp.num_window_groups = 1;
++    ssch->scp.transf_length_idx[0] = 4;
++
++    return asf_psy_elements(s, ss, ssch, n_grp_bits);
++}
++
++static int mono_data(AC4DecodeContext *s, Substream *ss,
++                     int ch_id, int lfe, int iframe)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    GetBitContext *gb = &s->gbc;
++    int spec_frontend;
++    int ret;
++
++    if (lfe) {
++        spec_frontend = SF_ASF;
++        ret = sf_info_lfe(s, ss, ssch);
++    } else {
++        spec_frontend = get_bits1(gb);
++        ret = sf_info(s, ss, ch_id, spec_frontend, 0, 0);
++    }
++    if (ret < 0)
++        return ret;
++    return sf_data(s, ss, ch_id, iframe, spec_frontend);
++}
++
++static int two_channel_data(AC4DecodeContext *s, Substream *ss,
++                            const uint8_t ch_id[2], int x, int iframe)
++{
++    SubstreamChannel *ssch0 = &ss->ssch[ch_id[0]];
++    SubstreamChannel *ssch1 = &ss->ssch[ch_id[1]];
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ss->mdct_stereo_proc[x] = get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "mdct_stereo_proc[%d]: %d\n", x, ss->mdct_stereo_proc[x]);
++    if (ss->mdct_stereo_proc[x]) {
++        ret = sf_info(s, ss, ch_id[0], SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++
++        memcpy(&ssch1->scp, &ssch0->scp, sizeof(ss->ssch[0].scp));
++        memcpy(&ssch1->sect_sfb_offset, &ssch0->sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++        memcpy(&ssch1->offset2sfb, &ssch0->offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++        memcpy(&ssch1->offset2g, &ssch0->offset2g, sizeof(ss->ssch[0].offset2g));
++        memcpy(&ssch1->win_offset, &ssch0->win_offset, sizeof(ss->ssch[0].win_offset));
++
++        ret = chparam_info(s, ss, ch_id[0]);
++        if (ret < 0)
++            return ret;
++    } else {
++        ret = sf_info(s, ss, ch_id[0], SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++        ret = sf_info(s, ss, ch_id[1], SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++    }
++    ret = sf_data(s, ss, ch_id[0], iframe, SF_ASF);
++    if (ret < 0)
++        return ret;
++    ret = sf_data(s, ss, ch_id[1], iframe, SF_ASF);
++
++    return ret;
++}
++
++static int three_channel_info(AC4DecodeContext *s, Substream *ss,
++                              uint8_t ch_id[3])
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ss->chel_matsel = get_bits(gb, 4);
++    ret = chparam_info(s, ss, ch_id[0]);
++    if (ret < 0)
++        return ret;
++    return chparam_info(s, ss, ch_id[1]);
++}
++
++static int three_channel_data(AC4DecodeContext *s, Substream *ss,
++                              uint8_t ch_id[3], int iframe)
++{
++    SubstreamChannel *ssch0 = &ss->ssch[ch_id[0]];
++    SubstreamChannel *ssch1 = &ss->ssch[ch_id[1]];
++    SubstreamChannel *ssch2 = &ss->ssch[ch_id[2]];
++    int ret;
++
++    ret = sf_info(s, ss, ch_id[0], SF_ASF, 0, 0);
++    if (ret < 0)
++        return ret;
++
++    memcpy(&ssch1->scp, &ssch0->scp, sizeof(ss->ssch[0].scp));
++    memcpy(&ssch1->sect_sfb_offset, &ssch0->sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++    memcpy(&ssch1->offset2sfb, &ssch0->offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++    memcpy(&ssch1->offset2g, &ssch0->offset2g, sizeof(ss->ssch[0].offset2g));
++    memcpy(&ssch1->win_offset, &ssch0->win_offset, sizeof(ss->ssch[0].win_offset));
++
++    memcpy(&ssch2->scp, &ssch0->scp, sizeof(ss->ssch[0].scp));
++    memcpy(&ssch2->sect_sfb_offset, &ssch0->sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++    memcpy(&ssch2->offset2sfb, &ssch0->offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++    memcpy(&ssch2->offset2g, &ssch0->offset2g, sizeof(ss->ssch[0].offset2g));
++    memcpy(&ssch2->win_offset, &ssch0->win_offset, sizeof(ss->ssch[0].win_offset));
++
++    ret = three_channel_info(s, ss, ch_id);
++    if (ret < 0)
++        return ret;
++    ret = sf_data(s, ss, ch_id[0], iframe, SF_ASF);
++    if (ret < 0)
++        return ret;
++    ret = sf_data(s, ss, ch_id[1], iframe, SF_ASF);
++    if (ret < 0)
++        return ret;
++    ret = sf_data(s, ss, ch_id[2], iframe, SF_ASF);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int immers_cfg(AC4DecodeContext *s, Substream *ss)
++{
++    if (ss->im_codec_mode != IM_SCPL)
++        aspx_config(s, ss);
++
++    if (ss->im_codec_mode == IM_ASPX_ACPL_1)
++        acpl_config_1ch(s, ss, ACPL_PARTIAL);
++
++    if (ss->im_codec_mode == IM_ASPX_ACPL_2)
++        acpl_config_1ch(s, ss, ACPL_FULL);
++
++    return 0;
++}
++
++static const uint8_t immersive_ch_index[2][2][2] = {
++    {
++        { 0, 1 },
++        { 3, 4 },
++    },
++    {
++        { 0, 3 },
++        { 1, 4 },
++    },
++};
++
++static int immersive_channel_element(AC4DecodeContext *s, int lfe, int fronts, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret;
++
++    s->ch_map[AV_CHAN_FRONT_LEFT]      = 0;
++    s->ch_map[AV_CHAN_FRONT_RIGHT]     = 1;
++    s->ch_map[AV_CHAN_FRONT_CENTER]    = 2;
++    s->ch_map[AV_CHAN_LOW_FREQUENCY]   = 7;
++    s->ch_map[AV_CHAN_SIDE_LEFT]       = 3;
++    s->ch_map[AV_CHAN_SIDE_RIGHT]      = 4;
++    s->ch_map[AV_CHAN_BACK_LEFT]       = 5;
++    s->ch_map[AV_CHAN_BACK_RIGHT]      = 6;
++    s->ch_map[AV_CHAN_TOP_FRONT_LEFT]  = 8;
++    s->ch_map[AV_CHAN_TOP_FRONT_RIGHT] = 9;
++    s->ch_map[AV_CHAN_TOP_BACK_LEFT]   = 10;
++    s->ch_map[AV_CHAN_TOP_BACK_RIGHT]  = 11;
++
++    ss->im_codec_mode = get_bits1(gb);
++    if (!ss->im_codec_mode)
++        ss->im_codec_mode = get_bits(gb, 2);
++    else
++        ss->im_codec_mode = IM_ASPX_AJCC;
++    av_log(s->avctx, AV_LOG_DEBUG, "im_codec_mode: %d\n", ss->im_codec_mode);
++
++    if (iframe)
++        immers_cfg(s, ss);
++
++    if (lfe) {
++        ret = mono_data(s, ss, 7, 1, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (ss->im_codec_mode == IM_ASPX_AJCC)
++        companding_control(s, ss, 5);
++
++    ss->core_5ch_grouping = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "core_5ch_grouping: %d\n", ss->core_5ch_grouping);
++    switch (ss->core_5ch_grouping) {
++    case 0:
++        ss->mode_2ch = get_bits1(gb);
++        ret = two_channel_data(s, ss, immersive_ch_index[ss->mode_2ch][0], 0, iframe);
++        if (ret < 0)
++            return ret;
++        ret = two_channel_data(s, ss, immersive_ch_index[ss->mode_2ch][1], 1, iframe);
++        if (ret < 0)
++            return ret;
++        ret = mono_data(s, ss, 2, 0, iframe);
++        break;
++    case 1:
++        ret = three_channel_data(s, ss, (uint8_t []){0, 1, 2}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = two_channel_data(s, ss, (uint8_t []){3, 4}, 0, iframe);
++        if (ret < 0)
++            return ret;
++        break;
++    case 2:
++        ret = four_channel_data(s, ss, iframe, (uint8_t []){0, 1, 2, 3});
++        if (ret < 0)
++            return ret;
++        ret = mono_data(s, ss, 4, 0, iframe);
++        break;
++    case 3:
++        ret = five_channel_data(s, ss, iframe, (uint8_t []){0, 1, 2, 3, 4});
++        break;
++    }
++
++    if (ret < 0)
++        return ret;
++
++    if (ss->im_codec_mode != IM_ASPX_AJCC) {
++        ss->use_sap_add_ch = get_bits1(gb);
++
++        if (ss->use_sap_add_ch) {
++            ret = chparam_info(s, ss, 5);
++            if (ret < 0)
++                return ret;
++            ret = chparam_info(s, ss, 6);
++            if (ret < 0)
++                return ret;
++        }
++
++        ret = two_channel_data(s, ss, (uint8_t []){5, 6}, 2, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (ss->im_codec_mode == IM_ASPX_SCPL) {
++        ret = aspx_data_2ch(s, ss, (uint8_t []){0, 1}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_2ch(s, ss, (uint8_t []){2, 3}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, 7, iframe);
++        if (ret < 0)
++            return ret;
++
++        if (fronts) {
++            ret = aspx_data_2ch(s, ss, (uint8_t []){4, 5}, iframe);
++            if (ret < 0)
++                return ret;
++            ret = aspx_data_2ch(s, ss, (uint8_t []){6, 8}, iframe);
++            if (ret < 0)
++                return ret;
++        } else {
++            ret = aspx_data_2ch(s, ss, (uint8_t []){4, 5}, iframe);
++            if (ret < 0)
++                return ret;
++        }
++
++        ret = aspx_data_2ch(s, ss, (uint8_t []){9, 10}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_2ch(s, ss, (uint8_t []){10, 11}, iframe);
++        if (ret < 0)
++            return ret;
++    } else if (ss->im_codec_mode != IM_SCPL) {
++        ret = aspx_data_2ch(s, ss, (uint8_t []){0, 1}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_2ch(s, ss, (uint8_t []){3, 4}, iframe);
++        if (ret < 0)
++            return ret;
++
++        if (ss->im_codec_mode != IM_ASPX_AJCC) {
++            ret = aspx_data_2ch(s, ss, (uint8_t []){5, 6}, iframe);
++            if (ret < 0)
++                return ret;
++        }
++
++        ret = aspx_data_1ch(s, ss, 2, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (ss->im_codec_mode == IM_ASPX_AJCC)
++        ;
++
++    if (ss->im_codec_mode == IM_SCPL ||
++        ss->im_codec_mode == IM_ASPX_SCPL ||
++        ss->im_codec_mode == IM_ASPX_ACPL_1) {
++        ret = two_channel_data(s, ss, (uint8_t []){8, 9}, 3, iframe);
++        if (ret < 0)
++            return ret;
++
++        ret = two_channel_data(s, ss, (uint8_t []){10, 11}, 4, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (ss->im_codec_mode == IM_ASPX_ACPL_1 ||
++        ss->im_codec_mode == IM_ASPX_ACPL_2) {
++        ret = acpl_data_1ch(s, ss, 0);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, 1);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, 2);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, 3);
++        if (ret < 0)
++            return ret;
++        if (fronts) {
++            ret = acpl_data_1ch(s, ss, 4);
++            if (ret < 0)
++                return ret;
++            ret = acpl_data_1ch(s, ss, 5);
++            if (ret < 0)
++                return ret;
++        }
++    }
++
++    return 0;
++}
++
++static int channel_element_7x(AC4DecodeContext *s, int channel_mode, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret = 0;
++
++    ss->codec_mode = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode != CM_SIMPLE)
++            aspx_config(s, ss);
++        if (ss->codec_mode == CM_ASPX_ACPL_1)
++            acpl_config_1ch(s, ss, ACPL_PARTIAL);
++        if (ss->codec_mode == CM_ASPX_ACPL_2)
++            acpl_config_1ch(s, ss, ACPL_FULL);
++    }
++
++    if (channel_mode == 6) {
++        ret = mono_data(s, ss, 7, 1, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (ss->codec_mode == CM_ASPX_ACPL_1 ||
++        ss->codec_mode == CM_ASPX_ACPL_2)
++        companding_control(s, ss, 5);
++
++    ss->coding_config = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "coding config: %d\n", ss->coding_config);
++    switch (ss->coding_config) {
++    case 0:
++        ss->mode_2ch = get_bits1(gb);
++        ret = two_channel_data(s, ss, (uint8_t []){0, 1}, 0, iframe);
++        if (ret < 0)
++            return ret;
++        ret = two_channel_data(s, ss, (uint8_t []){2, 3}, 1, iframe);
++        break;
++    case 1:
++        ret = three_channel_data(s, ss, (uint8_t []){0, 1, 2}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = two_channel_data(s, ss, (uint8_t []){3, 4}, 1, iframe);
++        break;
++    case 2:
++        ret = four_channel_data(s, ss, iframe, (uint8_t []){0, 1, 2, 3});
++        break;
++    case 3:
++        ret = five_channel_data(s, ss, iframe, (uint8_t []){0, 1, 2, 3, 4});
++        break;
++    default:
++        av_assert0(0);
++    }
++    if (ret < 0)
++        return ret;
++
++    if (ss->codec_mode == CM_SIMPLE || ss->codec_mode == CM_ASPX) {
++        if (get_bits1(gb)) {
++            chparam_info(s, ss, 5);
++            chparam_info(s, ss, 6);
++        }
++        ret = two_channel_data(s, ss, (uint8_t []){5, 6}, 1, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (ss->codec_mode == CM_ASPX_ACPL_1) {
++        // XXX
++    }
++
++    return ret;
++}
++
++static int channel_element_3x(AC4DecodeContext *s, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret;
++
++    ss->codec_mode = get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (ss->codec_mode == CM_ASPX) {
++        if (iframe)
++            aspx_config(s, ss);
++        companding_control(s, ss, 3);
++    }
++
++    s->ch_map[AV_CHAN_FRONT_LEFT]   = 0;
++    s->ch_map[AV_CHAN_FRONT_RIGHT]  = 1;
++    s->ch_map[AV_CHAN_FRONT_CENTER] = 2;
++
++    ss->coding_config = get_bits1(gb);
++    switch (ss->coding_config) {
++    case 0:
++        ret = stereo_data(s, ss, iframe);
++        if (ret < 0)
++            return ret;
++        ret = mono_data(s, ss, 2, 0, iframe);
++        if (ret < 0)
++            return ret;
++        break;
++    case 1:
++        ret = three_channel_data(s, ss, (uint8_t []){0, 1, 2}, iframe);
++        if (ret < 0)
++            return ret;
++        break;
++    }
++
++    if (ss->codec_mode == CM_ASPX) {
++        ret = aspx_data_2ch(s, ss, (uint8_t []){0, 1}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, 2, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int channel_element_5x(AC4DecodeContext *s, int lfe, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret = 0;
++
++    ss->codec_mode = get_bits(gb, 3);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode != CM_SIMPLE)
++            aspx_config(s, ss);
++        if (ss->codec_mode == CM_ASPX_ACPL_1)
++            acpl_config_1ch(s, ss, ACPL_PARTIAL);
++        if (ss->codec_mode == CM_ASPX_ACPL_2)
++            acpl_config_1ch(s, ss, ACPL_FULL);
++        if (ss->codec_mode == CM_ASPX_ACPL_3)
++            acpl_config_2ch(s, ss);
++    }
++
++    if (lfe) {
++        s->ch_map[AV_CHAN_LOW_FREQUENCY] = 5;
++
++        ret = mono_data(s, ss, 5, 1, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    switch (ss->codec_mode) {
++    case CM_SIMPLE:
++    case CM_ASPX:
++        if (ss->codec_mode == CM_ASPX)
++            companding_control(s, ss, 5);
++
++        ss->coding_config = get_bits(gb, 2);
++        av_log(s->avctx, AV_LOG_DEBUG, "coding_config: %d\n", ss->coding_config);
++        switch (ss->coding_config) {
++        case 0:
++            ss->mode_2ch = get_bits1(gb);
++
++            av_log(s->avctx, AV_LOG_DEBUG, "mode_2ch: %d\n", ss->mode_2ch);
++
++            if (ss->mode_2ch) {
++                s->ch_map[AV_CHAN_FRONT_LEFT]  = 0;
++                s->ch_map[AV_CHAN_SIDE_LEFT]   = 1;
++                s->ch_map[AV_CHAN_FRONT_RIGHT] = 2;
++                s->ch_map[AV_CHAN_SIDE_RIGHT]  = 3;
++            } else {
++                s->ch_map[AV_CHAN_FRONT_LEFT]  = 0;
++                s->ch_map[AV_CHAN_FRONT_RIGHT] = 1;
++                s->ch_map[AV_CHAN_SIDE_LEFT]   = 2;
++                s->ch_map[AV_CHAN_SIDE_RIGHT]  = 3;
++            }
++            s->ch_map[AV_CHAN_FRONT_CENTER] = 4;
++
++            ret = two_channel_data(s, ss, (uint8_t []){0, 1}, 0, iframe);
++            if (ret < 0)
++                return ret;
++            ret = two_channel_data(s, ss, (uint8_t []){2, 3}, 1, iframe);
++            if (ret < 0)
++                return ret;
++            ret = mono_data(s, ss, 4, 0, iframe);
++            break;
++        case 1:
++            s->ch_map[AV_CHAN_FRONT_LEFT]   = 0;
++            s->ch_map[AV_CHAN_FRONT_RIGHT]  = 1;
++            s->ch_map[AV_CHAN_FRONT_CENTER] = 2;
++            s->ch_map[AV_CHAN_SIDE_LEFT]    = 3;
++            s->ch_map[AV_CHAN_SIDE_RIGHT]   = 4;
++
++            ret = three_channel_data(s, ss, (uint8_t []){0, 1, 2}, iframe);
++            if (ret < 0)
++                return ret;
++            ret = two_channel_data(s, ss, (uint8_t []){3, 4}, 0, iframe);
++            break;
++        case 2:
++            s->ch_map[AV_CHAN_FRONT_LEFT]   = 0;
++            s->ch_map[AV_CHAN_FRONT_RIGHT]  = 1;
++            s->ch_map[AV_CHAN_SIDE_LEFT]    = 2;
++            s->ch_map[AV_CHAN_SIDE_RIGHT]   = 3;
++            s->ch_map[AV_CHAN_FRONT_CENTER] = 4;
++
++            ret = four_channel_data(s, ss, iframe, (uint8_t []){0, 1, 2, 3});
++            if (ret < 0)
++                return ret;
++            ret = mono_data(s, ss, 4, 0, iframe);
++            break;
++        case 3:
++            s->ch_map[AV_CHAN_FRONT_LEFT]   = 0;
++            s->ch_map[AV_CHAN_FRONT_RIGHT]  = 1;
++            s->ch_map[AV_CHAN_FRONT_CENTER] = 2;
++            s->ch_map[AV_CHAN_SIDE_LEFT]    = 3;
++            s->ch_map[AV_CHAN_SIDE_RIGHT]   = 4;
++
++            ret = five_channel_data(s, ss, iframe, (uint8_t []){0, 1, 2, 3, 4});
++            break;
++        }
++        if (ret < 0)
++            return ret;
++
++        if (ss->codec_mode == CM_ASPX) {
++            ret = aspx_data_2ch(s, ss, (uint8_t []){0, 1}, iframe);
++            if (ret < 0)
++                return ret;
++            ret = aspx_data_2ch(s, ss, (uint8_t []){2, 3}, iframe);
++            if (ret < 0)
++                return ret;
++            ret = aspx_data_1ch(s, ss, 4, iframe);
++            if (ret < 0)
++                return ret;
++        }
++        break;
++    case CM_ASPX_ACPL_1:
++    case CM_ASPX_ACPL_2:
++        companding_control(s, ss, 3);
++        ss->coding_config = get_bits1(gb);
++        av_log(s->avctx, AV_LOG_DEBUG, "coding_config: %d\n", ss->coding_config);
++        if (ss->coding_config)
++            ret = three_channel_data(s, ss, (uint8_t []){0, 1, 2}, iframe);
++        else
++            ret = two_channel_data(s, ss, (uint8_t []){0, 1}, 0, iframe);
++        if (ret < 0)
++            return ret;
++
++        if (ss->codec_mode == CM_ASPX_ACPL_1) {
++            ss->max_sfb_master = get_bits(gb, 5); // XXX
++            ret = chparam_info(s, ss, 2 + ss->coding_config);
++            if (ret < 0)
++                return ret;
++            ret = chparam_info(s, ss, 3 + ss->coding_config);
++            if (ret < 0)
++                return ret;
++            ret = sf_data(s, ss, 2 + ss->coding_config, iframe, SF_ASF);
++            if (ret < 0)
++                return ret;
++            ret = sf_data(s, ss, 3 + ss->coding_config, iframe, SF_ASF);
++            if (ret < 0)
++                return ret;
++        }
++        if (ss->coding_config == 0) {
++            ret = mono_data(s, ss, 2, 0, iframe);
++            if (ret < 0)
++                return ret;
++        }
++
++        s->ch_map[AV_CHAN_FRONT_LEFT]   = 0;
++        s->ch_map[AV_CHAN_FRONT_RIGHT]  = 1;
++        s->ch_map[AV_CHAN_FRONT_CENTER] = 2;
++        s->ch_map[AV_CHAN_SIDE_LEFT]    = 3;
++        s->ch_map[AV_CHAN_SIDE_RIGHT]   = 4;
++
++        ret = aspx_data_2ch(s, ss, (uint8_t []){0, 1}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, 2, iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, 0);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, 1);
++        break;
++    case CM_ASPX_ACPL_3:
++        companding_control(s, ss, 2);
++        ret = stereo_data(s, ss, iframe);
++        if (ret < 0)
++            return ret;
++
++        s->ch_map[AV_CHAN_FRONT_LEFT]   = 0;
++        s->ch_map[AV_CHAN_FRONT_RIGHT]  = 1;
++        s->ch_map[AV_CHAN_FRONT_CENTER] = 2;
++        s->ch_map[AV_CHAN_SIDE_LEFT]    = 3;
++        s->ch_map[AV_CHAN_SIDE_RIGHT]   = 4;
++
++        ret = aspx_data_2ch(s, ss, (uint8_t []){0, 1}, iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_2ch(s, ss, &ss->ssch[0], &ss->ssch[1]);
++        break;
++    default:
++        av_log(s->avctx, AV_LOG_ERROR, "invalid codec mode: %d\n", ss->codec_mode);
++        return AVERROR_INVALIDDATA;
++    }
++
++    return ret;
++}
++
++static int single_channel_element(AC4DecodeContext *s, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret = 0;
++
++    s->ch_map[AV_CHAN_FRONT_CENTER] = 0;
++
++    ss->codec_mode = get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode == CM_ASPX)
++            aspx_config(s, ss);
++    }
++    if (ss->codec_mode == CM_SIMPLE) {
++        ret = mono_data(s, ss, 0, 0, iframe);
++    } else {
++        companding_control(s, ss, 1);
++        ret = mono_data(s, ss, 0, 0, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, 0, iframe);
++    }
++
++    return ret;
++}
++
++static int audio_data(AC4DecodeContext *s, int channel_mode, int iframe)
++{
++    int ret = 0;
++
++    av_log(s->avctx, AV_LOG_DEBUG, "channel_mode: %d\n", channel_mode);
++    switch (channel_mode) {
++    case 0:
++        ret = single_channel_element(s, iframe);
++        break;
++    case 1:
++        ret = channel_pair_element(s, iframe);
++        break;
++    case 2:
++        ret = channel_element_3x(s, iframe);
++        break;
++    case 3:
++        ret = channel_element_5x(s, 0, iframe);
++        break;
++    case 4:
++        ret = channel_element_5x(s, 1, iframe);
++        break;
++    case 5:
++        ret = channel_element_7x(s, channel_mode, iframe);
++        break;
++    case 6:
++        ret = channel_element_7x(s, channel_mode, iframe);
++        break;
++    case 11:
++        ret = immersive_channel_element(s, 0, 0, iframe);
++        break;
++    case 12:
++        ret = immersive_channel_element(s, 1, 0, iframe);
++        break;
++    case 13:
++        ret = immersive_channel_element(s, 0, 1, iframe);
++        break;
++    case 14:
++        ret = immersive_channel_element(s, 1, 1, iframe);
++        break;
++    default:
++        avpriv_report_missing_feature(s->avctx, "channel_mode = %d", channel_mode);
++        return AVERROR_PATCHWELCOME;
++    }
++
++    return ret;
++}
++
++static int ac4_substream(AC4DecodeContext *s,
++                         SubstreamGroupInfo *ssginfo,
++                         SubstreamInfo *ssinfo,
++                         int substream_size)
++{
++    GetBitContext *gb = &s->gbc;
++    int audio_size, offset, consumed, ret;
++
++    audio_size = get_bits(gb, 15);
++    if (get_bits1(gb))
++        audio_size += variable_bits(gb, 7) << 15;
++    if (audio_size > 131072 ||
++        (substream_size > 0 && audio_size > substream_size)) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid audio_size: %d\n", audio_size);
++        return AVERROR_INVALIDDATA;
++    }
++
++    av_log(s->avctx, AV_LOG_DEBUG, "audio_size: %d\n", audio_size);
++
++    align_get_bits(gb);
++
++    offset = get_bits_count(gb) >> 3;
++    if (ssginfo->channel_coded) {
++        ret = audio_data(s, ssinfo->channel_mode, ssinfo->iframe[0]);
++    } else {
++        if (ssginfo->ajoc) {
++            //audio_data_ajoc();
++        } else {
++            //audio_data_objs();
++        }
++
++        ret = AVERROR_PATCHWELCOME;
++    }
++    if (ret < 0)
++        return ret;
++
++    align_get_bits(gb);
++    consumed = (get_bits_count(gb) >> 3) - offset;
++    if (consumed > audio_size)
++        av_log(s->avctx, AV_LOG_WARNING, "substream audio data overread: %d\n", consumed - audio_size);
++
++    if (consumed < audio_size) {
++        int non_zero = 0;
++
++        for (int i = consumed; i < audio_size; i++)
++            non_zero += !!get_bits(gb, 8);
++        if (non_zero)
++            av_log(s->avctx, AV_LOG_WARNING, "substream audio data underread: %d\n", non_zero);
++    }
++
++    align_get_bits(gb);
++
++    if (substream_size > 0)
++        skip_bits_long(gb, (substream_size - audio_size - 2) * 8);
++
++    return 0;
++}
++
++/*
++static int further_loudness_info(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++    Metadata *m = &ssi->meta;
++
++    m->loudness_version = get_bits(gb, 2);
++    if (m->loudness_version == 3)
++        m->loudness_version += get_bits(gb, 4);
++
++    m->loud_prac_type = get_bits(gb, 4);
++    if (m->loud_prac_type != 0) {
++        if (get_bits1(gb))
++            m->dialgate_prac_type = get_bits(gb, 3);
++        m->loudcorr_type = get_bits1(gb);
++    }
++
++    if (get_bits1(gb))
++        m->loudrelgat = get_bits(gb, 11);
++
++    if (get_bits1(gb)) {
++        m->loudspchgat = get_bits(gb, 11);
++        m->dialgate_prac_type = get_bits(gb, 3);
++    }
++
++    if (get_bits1(gb))
++        m->loudstrm3s = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->max_loudstrm3s = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->truepk = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->max_truepk = get_bits(gb, 11);
++
++    if (get_bits1(gb)) {
++        int prgmbndy_bit = 0;
++
++        m->prgmbndy = 1;
++        while (prgmbndy_bit == 0) {
++            m->prgmbndy <<= 1;
++            prgmbndy_bit = get_bits1(gb);
++        }
++
++        m->end_or_start = get_bits1(gb);
++        if (get_bits1(gb))
++            m->prgmbndy_offset = get_bits(gb, 11);
++    }
++
++    if (get_bits1(gb)) {
++        m->lra = get_bits(gb, 10);
++        m->lra_prac_type = get_bits(gb, 3);
++    }
++
++    if (get_bits1(gb))
++        m->loudmntry = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->max_loudmntry = get_bits(gb, 11);
++
++    if (get_bits1(gb)) {
++        int e_bits_size = get_bits(gb, 5);
++        if (e_bits_size == 31)
++            e_bits_size += variable_bits(gb, 4);
++        skip_bits_long(gb, e_bits_size);
++    }
++
++    return 0;
++}
++
++static int channel_mode_contains_lfe(int channel_mode)
++{
++    if (channel_mode == 4 ||
++        channel_mode == 6 ||
++        channel_mode == 8 ||
++        channel_mode == 10)
++        return 1;
++    return 0;
++}
++
++static int basic_metadata(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++    Metadata *m = &ssi->meta;
++
++    if (ssi->sus_ver == 0)
++        m->dialnorm_bits = get_bits(gb, 7);
++
++    if (get_bits1(gb)) {
++        if (get_bits1(gb))
++            further_loudness_info(s, ssi);
++        if (ssi->channel_mode == 1) {
++            if (get_bits1(gb)) {
++                m->pre_dmixtyp_2ch = get_bits(gb, 3);
++                m->phase90_info_2ch = get_bits(gb, 2);
++            }
++        }
++
++        if (ssi->channel_mode > 1) {
++            if (get_bits1(gb)) {
++                m->loro_center_mixgain = get_bits(gb, 3);
++                m->loro_surround_mixgain = get_bits(gb, 3);
++                if (get_bits1(gb))
++                    m->loro_dmx_loud_corr = get_bits(gb, 5);
++                if (get_bits1(gb)) {
++                    m->ltrt_center_mixgain = get_bits(gb, 3);
++                    m->ltrt_surround_mixgain = get_bits(gb, 3);
++                }
++                if (get_bits1(gb))
++                    m->ltrt_dmx_loud_corr = get_bits(gb, 5);
++                if (channel_mode_contains_lfe(ssi->channel_mode)) {
++                    if (get_bits1(gb))
++                        m->lfe_mixgain = get_bits(gb, 5);
++                }
++                m->preferred_dmx_method = get_bits(gb, 2);
++            }
++            if (ssi->channel_mode == 3 ||
++                ssi->channel_mode == 4) {
++                if (get_bits1(gb))
++                    m->pre_dmixtyp_5ch = get_bits(gb, 3);
++                if (get_bits1(gb))
++                    m->pre_upmixtyp_5ch = get_bits(gb, 4);
++            }
++
++            if (ssi->channel_mode >= 5 && ssi->channel_mode <= 10) {
++                if (get_bits1(gb)) {
++                    if (ssi->channel_mode >= 5 && ssi->channel_mode <= 6) {
++                        m->pre_upmixtyp_3_4 = get_bits(gb, 2);
++                    } else if (ssi->channel_mode >= 9 && ssi->channel_mode <= 10) {
++                        m->pre_upmixtyp_3_2_2 = get_bits(gb, 1);
++                    }
++                }
++            }
++            m->phase90_info_mc = get_bits(gb, 2);
++            m->surround_attenuation_known = get_bits1(gb);
++            m->lfe_attenuation_known = get_bits1(gb);
++        }
++
++        if (get_bits1(gb))
++            m->dc_block_on = get_bits1(gb);
++    }
++    return 0;
++}
++
++static int extended_metadata(AC4DecodeContext *s)
++{
++    return 0;
++}
++
++static int drc_decoder_mode_config(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    return 0;
++}
++
++static int drc_config(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++    Metadata *m = &ssi->meta;
++
++    m->drc_decoder_nr_modes = get_bits(gb, 3);
++    for (int i = 0; i <= m->drc_decoder_nr_modes; i++)
++        drc_decoder_mode_config(s, ssi);
++    m->drc_eac3_profile = get_bits(gb, 3);
++
++    return 0;
++}
++
++static int drc_data(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    return 0;
++}
++
++static int drc_frame(AC4DecodeContext *s, SubstreamInfo *ssi, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (get_bits1(gb)) {
++        if (iframe)
++            drc_config(s, ssi);
++
++        drc_data(s, ssi);
++    }
++
++    return 0;
++}
++
++static int dialog_enhancement(AC4DecodeContext *s, int iframe)
++{
++    return 0;
++}
++
++static int emdf_payloads_substream(AC4DecodeContext *s)
++{
++    return 0;
++}
++
++static int metadata(AC4DecodeContext *s, SubstreamInfo *ssi, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int tools_metadata_size;
++
++    basic_metadata(s, ssi);
++    extended_metadata(s);
++    tools_metadata_size = get_bits(gb, 7);
++    if (get_bits1(gb))
++        tools_metadata_size += variable_bits(gb, 3) << 7;
++
++    drc_frame(s, ssi, iframe);
++
++    dialog_enhancement(s, iframe);
++
++    if (get_bits1(gb))
++        emdf_payloads_substream(s);
++
++    return 0;
++}
++*/
++
++static void spectral_reordering(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float *scaled_spec = ssch->scaled_spec;
++    float *spec_reord = ssch->spec_reord;
++    int *win_offset = ssch->win_offset;
++    int k, win;
++
++    k = 0;
++    win = 0;
++    memset(ssch->spec_reord, 0, sizeof(ssch->spec_reord));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int transf_length_g = get_transf_length(s, ssch, g, NULL);
++        const uint16_t *sfb_offset = get_sfb_offset(transf_length_g);
++        int max_sfb = get_max_sfb(s, ssch, g);
++
++        av_assert2(max_sfb < get_sfb_size(transf_length_g));
++
++        for (int sfb = 0; sfb < max_sfb; sfb++) {
++            for (int w = 0; w < ssch->scp.num_win_in_group[g]; w++) {
++                for (int l = sfb_offset[sfb]; l < sfb_offset[sfb+1]; l++)
++                    spec_reord[win_offset[win+w] + l] = scaled_spec[k++];
++            }
++        }
++        win += ssch->scp.num_win_in_group[g];
++    }
++}
++
++static void scale_spec(AC4DecodeContext *s, int ch)
++{
++    Substream *ss = &s->substream;
++    SubstreamChannel *ssch = &ss->ssch[ch];
++    const float *quant_lut = s->quant_lut;
++
++    memset(ssch->scaled_spec, 0, sizeof(ssch->scaled_spec));
++
++    av_assert2(FF_ARRAY_ELEMS(ssch->scaled_spec) >= s->frame_len_base);
++    for (int k = 0; k < s->frame_len_base; k++) {
++        int x = ssch->quant_spec[k];
++        int sfb = ssch->offset2sfb[k];
++        int g = ssch->offset2g[k];
++
++        av_assert2(sfb < FF_ARRAY_ELEMS(ssch->sf_gain[g]));
++        av_assert2(g < FF_ARRAY_ELEMS(ssch->sf_gain));
++        av_assert2(FFABS(x) < FF_ARRAY_ELEMS(s->quant_lut));
++        ssch->scaled_spec[k] = ssch->sf_gain[g][sfb] * copysignf(quant_lut[FFABS(x)], x);
++    }
++}
++
++static int two_channel_processing(AC4DecodeContext *s, Substream *ss,
++                                  SubstreamChannel *ssch0,
++                                  SubstreamChannel *ssch1)
++{
++    int max_sfb_prev;
++    float sap_gain;
++
++    memset(ss->alpha_q, 0, sizeof(ss->alpha_q));
++
++    max_sfb_prev = get_max_sfb(s, ssch0, 0);
++    for (int g = 0; g < ssch0->scp.num_window_groups; g++) {
++        int max_sfb_g = get_max_sfb(s, ssch0, g);
++
++        for (int sfb = 0; sfb < max_sfb_g; sfb++) {
++            float m[2][2];
++
++            if (ssch0->sap_mode == 0 ||
++                (ssch0->sap_mode == 1 && ssch0->ms_used[g][sfb] == 0)) {
++                m[0][0] = m[1][1] = 1;
++                m[0][1] = m[1][0] = 0;
++            } else if (ssch0->sap_mode == 2 ||
++                       ((ssch0->sap_mode == 1 && ssch0->ms_used[g][sfb] == 1))) {
++                m[0][0] =
++                m[0][1] =
++                m[1][0] =  1;
++                m[1][1] = -1;
++            } else if (ssch0->sap_mode == 3) {
++                if (ssch0->sap_coeff_used[g][sfb]) { // setup alpha_q[g][sfb]
++                    if (sfb & 1) {
++                        ss->alpha_q[g][sfb] = ss->alpha_q[g][sfb-1];
++                    } else {
++                        int delta = ssch0->dpcm_alpha_q[g][sfb] - 60;
++                        int code_delta;
++
++                        if ((g == 0) || (max_sfb_g != max_sfb_prev)) {
++                            code_delta = 0;
++                        } else {
++                            code_delta = ssch0->delta_code_time;
++                        }
++
++                        if (code_delta) {
++                            ss->alpha_q[g][sfb] = ss->alpha_q[g-1][sfb] + delta;
++                        } else if (sfb == 0) {
++                            ss->alpha_q[g][sfb] = delta;
++                        } else {
++                            ss->alpha_q[g][sfb] = ss->alpha_q[g][sfb-2] + delta;
++                        }
++                    }
++                    // inverse quantize alpha_q[g][sfb]
++                    sap_gain = ss->alpha_q[g][sfb] * 0.1f;
++                    m[0][0] =  1 + sap_gain;
++                    m[0][1] =  1;
++                    m[1][0] =  1 - sap_gain;
++                    m[1][1] = -1;
++                } else {
++                    m[0][0] = 1;
++                    m[0][1] = 0;
++                    m[1][0] = 0;
++                    m[1][1] = 1;
++                }
++            }
++
++            memcpy(ss->matrix_stereo[g][sfb], m, sizeof(m));
++        }
++
++        max_sfb_prev = max_sfb_g;
++    }
++
++    for (int k = 0; k < s->frame_len_base; k++) {
++        int sfb = ssch0->offset2sfb[k];
++        int g = ssch0->offset2g[k];
++        float a = ss->matrix_stereo[g][sfb][0][0];
++        float b = ss->matrix_stereo[g][sfb][0][1];
++        float c = ss->matrix_stereo[g][sfb][1][0];
++        float d = ss->matrix_stereo[g][sfb][1][1];
++        float i0 = ssch0->scaled_spec[k];
++        float i1 = ssch1->scaled_spec[k];
++        float o0, o1;
++
++        o0 = i0 * a + i1 * b;
++        o1 = i0 * c + i1 * d;
++
++        ssch0->scaled_spec[k] = o0;
++        ssch1->scaled_spec[k] = o1;
++    }
++
++    return 0;
++}
++
++static int stereo_processing(AC4DecodeContext *s, Substream *ss)
++{
++    if (ss->mdct_stereo_proc[0])
++        two_channel_processing(s, ss, &ss->ssch[0], &ss->ssch[1]);
++
++    return 0;
++}
++
++static int m5channel_processing(AC4DecodeContext *s, Substream *ss)
++{
++    switch (ss->codec_mode) {
++    case CM_SIMPLE:
++    case CM_ASPX:
++        switch (ss->coding_config) {
++        case 0:
++            if (ss->mdct_stereo_proc[0])
++                two_channel_processing(s, ss, &ss->ssch[0], &ss->ssch[1]);
++            if (ss->mdct_stereo_proc[1])
++                two_channel_processing(s, ss, &ss->ssch[2], &ss->ssch[3]);
++            break;
++        }
++        break;
++    case CM_ASPX_ACPL_1:
++    case CM_ASPX_ACPL_2:
++    case CM_ASPX_ACPL_3:
++        switch (ss->coding_config) {
++        case 0:
++            if (ss->mdct_stereo_proc[0])
++                two_channel_processing(s, ss, &ss->ssch[0], &ss->ssch[1]);
++            break;
++        }
++        break;
++    }
++
++    return 0;
++}
++
++static void qmf_analysis(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float *qana_filt = ssch->qana_filt;
++    float *pcm = ssch->pcm;
++    LOCAL_ALIGNED_32(float, u, [MAX_QMF_BANDS*2]);
++    LOCAL_ALIGNED_32(float, z, [MAX_QMF_BANDS*10]);
++
++    for (int ts = 0; ts < s->num_qmf_timeslots; ts++) {
++        /* shift time-domain input samples by MAX_QMF_BANDS */
++        memmove(qana_filt + MAX_QMF_BANDS, qana_filt, sizeof(*qana_filt) * (MAX_QMF_BANDS*10 - MAX_QMF_BANDS));
++
++        /* feed new audio samples */
++        for (int sb = MAX_QMF_BANDS-1; sb >= 0; sb--)
++            qana_filt[sb] = pcm[ts * MAX_QMF_BANDS + MAX_QMF_BANDS-1 - sb] / 32768.f;
++
++        /* multiply input samples by window coefficients */
++        s->fdsp->vector_fmul(z, qana_filt, qwin, MAX_QMF_BANDS*10);
++
++        /* sum the samples to create vector u */
++        for (int n = 0; n < MAX_QMF_BANDS*2; n++) {
++            u[n] = z[n];
++            for (int k = 1; k < 5; k++)
++                u[n] += z[n + k * MAX_QMF_BANDS*2];
++        }
++
++        /* compute MAX_QMF_BANDS new subband samples */
++        for (int sb = 0; sb < MAX_QMF_BANDS; sb++) {
++            const float *cos_atab = s->cos_atab[sb];
++            const float *sin_atab = s->sin_atab[sb];
++
++            ssch->Q[0][ts][sb] = s->fdsp->scalarproduct_float(u, cos_atab, MAX_QMF_BANDS*2);
++            ssch->Q[1][ts][sb] = s->fdsp->scalarproduct_float(u, sin_atab, MAX_QMF_BANDS*2);
++        }
++    }
++}
++
++static void qmf_synthesis(AC4DecodeContext *s, SubstreamChannel *ssch, float *pcm)
++{
++    float *qsyn_filt = ssch->qsyn_filt;
++    LOCAL_ALIGNED_32(float, g, [MAX_QMF_BANDS*10]);
++    LOCAL_ALIGNED_32(float, w, [MAX_QMF_BANDS*10]);
++
++    for (int ts = 0; ts < s->num_qmf_timeslots; ts++) {
++        /* shift samples by MAX_QMF_BANDS*2 */
++        memmove(qsyn_filt + MAX_QMF_BANDS*2, qsyn_filt, sizeof(*qsyn_filt) * (MAX_QMF_BANDS*20 - MAX_QMF_BANDS*2));
++
++        for (int n = 0; n < MAX_QMF_BANDS*2; n++) {
++            const float *cos_stab = s->cos_stab[n];
++            const float *sin_stab = s->sin_stab[n];
++
++            qsyn_filt[n] = s->fdsp->scalarproduct_float(ssch->Q[0][ts], cos_stab, MAX_QMF_BANDS) -
++                           s->fdsp->scalarproduct_float(ssch->Q[1][ts], sin_stab, MAX_QMF_BANDS);
++        }
++
++        for (int n = 0; n < 5; n++) {
++            memcpy(g + MAX_QMF_BANDS*2 * n, qsyn_filt + 256 * n, MAX_QMF_BANDS * sizeof(float));
++            memcpy(g + MAX_QMF_BANDS*2 * n + MAX_QMF_BANDS, qsyn_filt + 256 * n + 192, MAX_QMF_BANDS * sizeof(float));
++        }
++        /* multiply by window coefficients */
++        s->fdsp->vector_fmul(w, g, qwin, MAX_QMF_BANDS*10);
++
++        /* compute MAX_QMF_BANDS new time-domain output samples */
++        for (int sb = 0; sb < MAX_QMF_BANDS; sb++) {
++            float temp = 0;
++
++            for (int n = 0; n < 10; n++)
++                temp += w[MAX_QMF_BANDS*n + sb];
++            pcm[ts*MAX_QMF_BANDS + sb] = temp;
++        }
++    }
++}
++
++static void spectral_synthesis(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    LOCAL_ALIGNED_32(float, swinl, [2048]);
++    LOCAL_ALIGNED_32(float, swinr, [2048]);
++    const int *win_offset = ssch->win_offset;
++    const int N_full = s->frame_len_base;
++    float *imdct_out = ssch->imdct_out;
++    float *overlap = ssch->overlap;
++    float *pcm = ssch->pcm;
++    int win = 0;
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int midx = s->frame_len_base_idx, idx;
++        const int N = get_transf_length(s, ssch, g, &idx);
++        const int N_prev = !ssch->N_prev ? N_full : ssch->N_prev;
++        const int N_w = FFMIN(N, N_prev);
++        const float *winl = s->kbd_window[midx][idx];
++        const float *winr = s->kbd_window[midx][ssch->idx_prev];
++        const float *winf = (N_w == N) ? winl : winr;
++        const int wnskip_prev = (N_prev - N_w) >> 1;
++        const int wnskip = (N - N_w) >> 1;
++        const int nskip_prev = (N_full - N_prev) >> 1;
++        const int nskip = (N_full - N) >> 1;
++
++        av_assert2(wnskip + wnskip + N_w == N);
++        memset(swinl, 0, wnskip * sizeof(float));
++        memcpy(swinl + wnskip, winf, N_w * sizeof(float));
++        for (int n = 0; n < wnskip; n++)
++            swinl[wnskip + N_w + n] = 1.f;
++
++        av_assert2(wnskip_prev + wnskip_prev + N_w == N_prev);
++        memset(swinr, 0, wnskip_prev * sizeof(float));
++        memcpy(swinr + wnskip_prev, winf, N_w * sizeof(float));
++        for (int n = 0; n < wnskip_prev; n++)
++            swinr[wnskip_prev + N_w + n] = 1.f;
++
++        for (int w = 0; w < ssch->scp.num_win_in_group[g]; w++) {
++            s->tx_fn[midx][idx](s->tx_ctx[midx][idx], imdct_out,
++                                ssch->spec_reord + win_offset[win + w],
++                                sizeof(float));
++
++            s->fdsp->vector_fmul(imdct_out, imdct_out, swinl, N);
++            if (!(N_prev & 15))
++                s->fdsp->vector_fmul_reverse(overlap + nskip_prev,
++                                             overlap + nskip_prev, swinr, N_prev);
++            else
++                ac4_vector_fmul_reverse_c(overlap + nskip_prev,
++                                         overlap + nskip_prev, swinr, N_prev);
++
++            for (int n = 0; n < N; n++)
++                overlap[nskip + n] += imdct_out[n];
++
++            memcpy(pcm + win_offset[win + w], overlap, N * sizeof(float));
++            memmove(overlap, overlap + N, nskip * sizeof(float));
++            memcpy(overlap + nskip, imdct_out + N, N * sizeof(float));
++        }
++
++        ssch->N_prev = N;
++        ssch->idx_prev = idx;
++
++        win += ssch->scp.num_win_in_group[g];
++    }
++}
++
++#define MAX_ORDER 5
++
++static int polyfit(int order,
++                   int countOfElements,
++                   const float *const dependentValues,
++                   const float *const independentValues,
++                   float *coefficients)
++{
++    float B[MAX_ORDER + 1] = {0.0f};
++    float P[((MAX_ORDER + 1) * 2 ) + 1] = {0.0f};
++    float A[(MAX_ORDER + 1) * 2 * (MAX_ORDER + 1)] = {0.0f};
++    float x, y, powx;
++    int ii, jj, kk;
++
++    // This method requires that the countOfElements >
++    // (order+1)
++    if (countOfElements <= order)
++        return -1;
++
++    // This method has imposed an arbitrary bound of
++    // order <= MAX_ORDER.  Increase MAX_ORDER if necessary.
++    if (order > MAX_ORDER)
++        return -1;
++
++    // Identify the column vector
++    for (ii = 0; ii < countOfElements; ii++) {
++        x    = dependentValues[ii];
++        y    = independentValues[ii];
++        powx = 1;
++
++        for (jj = 0; jj < (order + 1); jj++) {
++            B[jj] = B[jj] + (y * powx);
++            powx  = powx * x;
++        }
++    }
++
++    // Initialize the PowX array
++    P[0] = countOfElements;
++    // Compute the sum of the Powers of X
++    for (ii = 0; ii < countOfElements; ii++) {
++        x    = dependentValues[ii];
++        powx = dependentValues[ii];
++
++        for (jj = 1; jj < (2 * (order + 1)) + 1; jj++) {
++            P[jj] = P[jj] + powx;
++            powx  = powx * x;
++        }
++    }
++
++    // Initialize the reduction matrix
++    //
++    for (ii = 0; ii < (order + 1); ii++) {
++        for (jj = 0; jj < (order + 1); jj++) {
++            A[(ii * (2 * (order + 1))) + jj] = P[ii+jj];
++        }
++        A[(ii*(2 * (order + 1))) + (ii + (order + 1))] = 1;
++    }
++
++    // Move the Identity matrix portion of the redux matrix
++    // to the left side (find the inverse of the left side
++    // of the redux matrix
++    for (ii = 0; ii < (order + 1); ii++) {
++        x = A[(ii * (2 * (order + 1))) + ii];
++        if (x != 0) {
++            for (kk = 0; kk < (2 * (order + 1)); kk++) {
++                A[(ii * (2 * (order + 1))) + kk] =
++                    A[(ii * (2 * (order + 1))) + kk] / x;
++            }
++
++            for (jj = 0; jj < (order + 1); jj++) {
++                if ((jj - ii) != 0) {
++                    y = A[(jj * (2 * (order + 1))) + ii];
++                    for (kk = 0; kk < (2 * (order + 1)); kk++) {
++                        A[(jj * (2 * (order + 1))) + kk] =
++                            A[(jj * (2 * (order + 1))) + kk] -
++                            y * A[(ii * (2 * (order + 1))) + kk];
++                    }
++                }
++            }
++        } else { // Cannot work with singular matrices
++            return 0;
++        }
++    }
++
++    // Calculate and Identify the coefficients
++    for (ii = 0; ii < order + 1; ii++) {
++        for (jj = 0; jj < order + 1; jj++) {
++            x = 0;
++            for (kk = 0; kk < (order + 1); kk++) {
++                x = x + (A[(ii * (2 * (order + 1))) + (kk + (order + 1))] *
++                         B[kk]);
++            }
++            coefficients[ii] = x;
++        }
++    }
++
++    return 0;
++}
++
++static int get_qsignal_scale_factors(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    int sbg_idx_high2low[24] = {0};
++    int sbg_idx_low2high[24] = {0};
++    int delta;
++
++    for (int sbg = 0, sbg_low = 0; sbg < ssch->num_sbg_sig_highres; sbg++) {
++        if (ssch->sbg_sig_lowres[sbg_low+1] == ssch->sbg_sig_highres[sbg]) {
++            sbg_low++;
++            sbg_idx_low2high[sbg_low] = sbg;
++        }
++        sbg_idx_high2low[sbg] = sbg_low;
++    }
++
++    delta = ((ch_id & 1) && (ssch->aspx_balance == 1)) + 1;
++
++    memcpy(ssch->qscf_sig_sbg_prev, ssch->qscf_sig_sbg, sizeof(ssch->qscf_sig_sbg));
++    memset(ssch->qscf_sig_sbg, 0, sizeof(ssch->qscf_sig_sbg));
++
++    if (ssch->num_atsg_sig_prev <= 0)
++        return AVERROR_INVALIDDATA;
++
++    /* Loop over Envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        int freqres_prev;
++
++        if (atsg == 0) {
++            freqres_prev = ssch->atsg_freqres[ssch->num_atsg_sig_prev - 1];
++        } else {
++            freqres_prev = ssch->atsg_freqres[atsg-1];
++        }
++
++        /* Loop over scale factor subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[atsg]; sbg++) {
++            int sbg_prev, v;
++
++            if (ssch->atsg_freqres[atsg] == freqres_prev) {
++                sbg_prev = sbg;
++            } else if (ssch->atsg_freqres[atsg] == 0 && freqres_prev == 1) {
++                sbg_prev = sbg_idx_low2high[sbg];
++            } else if (ssch->atsg_freqres[atsg] == 1 && freqres_prev == 0) {
++                sbg_prev = sbg_idx_high2low[sbg];
++            }
++
++            if (atsg == 0) {
++                ssch->qscf_prev[atsg][sbg] = ssch->qscf_sig_sbg_prev[ssch->num_atsg_sig_prev-1][sbg_prev];
++            } else {
++                ssch->qscf_prev[atsg][sbg] = ssch->qscf_sig_sbg[atsg-1][sbg_prev];
++            }
++
++            if (ssch->aspx_sig_delta_dir[atsg] == 0) { /* FREQ */
++                v = 0;
++                for (int i = 0; i <= sbg; i++)
++                    v += delta * ssch->aspx_data[0][atsg][i];
++            } else { /* TIME */
++                v  = ssch->qscf_prev[atsg][sbg];
++                v += delta * ssch->aspx_data[0][atsg][sbg];
++            }
++
++            av_assert2(v >= -128);
++            av_assert2(v <=  128);
++            ssch->qscf_sig_sbg[atsg][sbg] = v;
++        }
++    }
++
++    return 0;
++}
++
++static int get_qnoise_scale_factors(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    int delta;
++
++    delta = ((ch_id & 1) && (ssch->aspx_balance == 1)) + 1;
++
++    memcpy(ssch->qscf_noise_prev, ssch->qscf_noise_sbg, sizeof(ssch->qscf_noise_sbg));
++    memset(ssch->qscf_noise_sbg, 0, sizeof(ssch->qscf_noise_sbg));
++
++    ssch->num_atsg_noise_prev = FFMAX(1, ssch->num_atsg_noise_prev);
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_noise; atsg++) {
++        /* Loop over noise subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++) {
++            if (ssch->aspx_noise_delta_dir[atsg] == 0) { /* FREQ */
++                for (int i = 0; i <= sbg; i++)
++                    ssch->qscf_noise_sbg[atsg][sbg] += delta * ssch->aspx_data[1][atsg][i];
++            } else { /* TIME */
++                if (atsg == 0) {
++                    ssch->qscf_noise_sbg[atsg][sbg]  = ssch->qscf_noise_prev[ssch->num_atsg_noise_prev-1][sbg];
++                    ssch->qscf_noise_sbg[atsg][sbg] += delta * ssch->aspx_data[1][atsg][sbg];
++                } else {
++                    ssch->qscf_noise_sbg[atsg][sbg]  = ssch->qscf_noise_sbg[atsg-1][sbg];
++                    ssch->qscf_noise_sbg[atsg][sbg] += delta * ssch->aspx_data[1][atsg][sbg];
++                }
++            }
++
++            av_assert2(ssch->qscf_noise_sbg[atsg][sbg] >= -63);
++            av_assert2(ssch->qscf_noise_sbg[atsg][sbg] <=  63);
++        }
++    }
++
++    return 0;
++}
++
++static void prepare_channel(AC4DecodeContext *s, int ch)
++{
++    Substream *ss = &s->substream;
++    SubstreamChannel *ssch = &ss->ssch[ch];
++
++    spectral_reordering(s, ssch);
++    spectral_synthesis(s, ssch);
++
++    qmf_analysis(s, ssch);
++}
++
++static void aspx_processing(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    const int num_qmf_timeslots = s->num_qmf_timeslots;
++    const int ts_offset_hfgen = s->ts_offset_hfgen;
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++
++    memcpy(ssch->Q_low_prev, ssch->Q_low, sizeof(ssch->Q_low));
++    memset(ssch->Q_low, 0, sizeof(ssch->Q_low));
++
++    for (int ts = 0; ts < ts_offset_hfgen; ts++) {
++        for (int sb = 0; sb < MAX_QMF_BANDS; sb++) {
++            if (sb < ssch->sbx) {
++                ssch->Q_low[0][ts][sb] = ssch->Q_prev[0][ts + num_qmf_timeslots - ts_offset_hfgen][sb];
++                ssch->Q_low[1][ts][sb] = ssch->Q_prev[1][ts + num_qmf_timeslots - ts_offset_hfgen][sb];
++            }
++        }
++    }
++
++    for (int ts = ts_offset_hfgen; ts < num_qmf_timeslots + ts_offset_hfgen; ts++) {
++        for (int sb = 0; sb < MAX_QMF_BANDS; sb++) {
++            if (sb < ssch->sbx) {
++                ssch->Q_low[0][ts][sb] = ssch->Q[0][ts - ts_offset_hfgen][sb];
++                ssch->Q_low[1][ts][sb] = ssch->Q[1][ts - ts_offset_hfgen][sb];
++            }
++        }
++    }
++}
++
++static void mono_deq_signal_factors(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    const float a = 1 + (ssch->aspx_qmode_env == 0);
++    const float b = ssch->sbx;
++
++    memset(ssch->scf_sig_sbg, 0, sizeof(ssch->scf_sig_sbg));
++
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[ssch->atsg_freqres[atsg]]; sbg++)
++            ssch->scf_sig_sbg[atsg][sbg] = b * powf(2.f, ssch->qscf_sig_sbg[atsg][sbg] / a);
++
++        if (ssch->aspx_sig_delta_dir[atsg] == 0 &&
++            ssch->qscf_sig_sbg[atsg][0] == 0 &&
++            ssch->scf_sig_sbg[atsg][1] < 0) {
++            ssch->scf_sig_sbg[atsg][0] = ssch->scf_sig_sbg[atsg][1];
++        }
++    }
++}
++
++static void mono_deq_noise_factors(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++#define NOISE_FLOOR_OFFSET 6
++    memset(ssch->scf_noise_sbg, 0, sizeof(ssch->scf_noise_sbg));
++
++    for (int atsg = 0; atsg < ssch->num_atsg_noise; atsg++) {
++        for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++)
++            ssch->scf_noise_sbg[atsg][sbg] = powf(2.f, NOISE_FLOOR_OFFSET - ssch->qscf_noise_sbg[atsg][sbg]);
++    }
++}
++
++static void joint_deq_signoise_factors(AC4DecodeContext *s,
++                                       Substream *ss, uint8_t ch_id[2])
++{
++    SubstreamChannel *ssch0 = &ss->ssch[ch_id[0]];
++    SubstreamChannel *ssch1 = &ss->ssch[ch_id[1]];
++#define PAN_OFFSET 12
++    const float a = 1 + (ssch0->aspx_qmode_env == 0);
++    const float b = ssch0->sbx;
++
++    memset(ssch0->scf_sig_sbg, 0, sizeof(ssch0->scf_sig_sbg));
++    memset(ssch0->scf_noise_sbg, 0, sizeof(ssch0->scf_noise_sbg));
++
++    memset(ssch1->scf_sig_sbg, 0, sizeof(ssch1->scf_sig_sbg));
++    memset(ssch1->scf_noise_sbg, 0, sizeof(ssch1->scf_noise_sbg));
++
++    for (int atsg = 0; atsg < ssch0->num_atsg_sig; atsg++) {
++        for (int sbg = 0; sbg < ssch0->num_sbg_sig[ssch0->atsg_freqres[atsg]]; sbg++) {
++            float nom = b * powf(2.f, ssch0->qscf_sig_sbg[atsg][sbg] / a + 1.f);
++            float denom_a = 1.f + powf(2.f, PAN_OFFSET - ssch1->qscf_sig_sbg[atsg][sbg] / a);
++            float denom_b = 1.f + powf(2.f, ssch1->qscf_sig_sbg[atsg][sbg] / a - PAN_OFFSET);
++
++            ssch0->scf_sig_sbg[atsg][sbg] = nom / denom_a;
++            ssch1->scf_sig_sbg[atsg][sbg] = nom / denom_b;
++        }
++    }
++
++    for (int atsg = 0; atsg < ssch0->num_atsg_noise; atsg++) {
++        for (int sbg = 0; sbg < ssch0->num_sbg_noise; sbg++) {
++            float nom = powf(2.f, NOISE_FLOOR_OFFSET - ssch0->qscf_noise_sbg[atsg][sbg] + 1.f);
++            float denom_a = 1.f + powf(2.f, PAN_OFFSET - ssch1->qscf_noise_sbg[atsg][sbg]);
++            float denom_b = 1.f + powf(2.f, ssch1->qscf_noise_sbg[atsg][sbg] - PAN_OFFSET);
++
++            ssch0->scf_noise_sbg[atsg][sbg] = nom / denom_a;
++            ssch1->scf_noise_sbg[atsg][sbg] = nom / denom_b;
++        }
++    }
++}
++
++static void preflattening(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    float mean_energy = 0;
++    int polynomial_order = 3;
++    int num_qmf_subbands = ssch->sbx;
++    float poly_array[MAX_QMF_BANDS];
++    float pow_env[MAX_QMF_BANDS];
++    float slope[MAX_QMF_BANDS];
++    float x[MAX_QMF_BANDS];
++
++    if (ssch->sbx < 3)
++        return;
++
++    for (int i = 0; i < num_qmf_subbands; i++) {
++        x[i] = i;
++        slope[i] = 0;
++    }
++    /* Calculate the spectral signal envelope in dB over the current interval. */
++    for (int sb = 0; sb < num_qmf_subbands; sb++) {
++        float denom, nom = 0.f;
++
++        for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats; ts < ssch->atsg_sig[ssch->num_atsg_sig] * s->num_ts_in_ats; ts++) {
++            nom += powf(ssch->Q_low[0][ts][sb], 2);
++            nom += powf(ssch->Q_low[1][ts][sb], 2);
++        }
++
++        denom = (ssch->atsg_sig[ssch->num_atsg_sig] - ssch->atsg_sig[0]) * s->num_ts_in_ats;
++        pow_env[sb] = nom / denom;
++        pow_env[sb] = 10.f * log10f(pow_env[sb] + 1.f);
++        mean_energy += pow_env[sb];
++    }
++
++    mean_energy /= num_qmf_subbands;
++    av_assert2(polyfit(polynomial_order, num_qmf_subbands, x, pow_env, poly_array) == 0);
++
++    /* Transform polynomial into slope */
++    for (int k = polynomial_order; k >= 0; k--) {
++        for (int sb = 0; sb < num_qmf_subbands; sb++)
++            slope[sb] += powf(x[sb], k) * poly_array[k];
++    }
++
++    /* Derive a gain vector from the slope */
++    av_assert2(num_qmf_subbands <= FF_ARRAY_ELEMS(ssch->gain_vec));
++    for (int sb = 0; sb < num_qmf_subbands; sb++)
++        ssch->gain_vec[sb] = powf(10, (mean_energy - slope[sb]) / 20.f);
++}
++
++static void get_chirps(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    memcpy(ssch->chirp_arr_prev, ssch->chirp_arr, sizeof(ssch->chirp_arr));
++
++    for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++) {
++        float new_chirp = new_chirp_tab[ssch->aspx_tna_mode[sbg]][ssch->aspx_tna_mode_prev[sbg]];
++
++        av_assert2(ssch->aspx_tna_mode[sbg] <= 3);
++        av_assert2(ssch->aspx_tna_mode_prev[sbg] <= 3);
++        if (new_chirp < ssch->chirp_arr_prev[sbg]) {
++            new_chirp = 0.75000f * new_chirp + 0.25000f * ssch->chirp_arr_prev[sbg];
++        } else {
++            new_chirp = 0.90625f * new_chirp + 0.09375f * ssch->chirp_arr_prev[sbg];
++        }
++
++        if (new_chirp < 0.015625f) {
++            ssch->chirp_arr[sbg] = 0.f;
++        } else {
++            ssch->chirp_arr[sbg] = new_chirp;
++        }
++    }
++}
++
++static void fcomplex_mul(float *r, float *i, float x, float yi, float u, float vi)
++{
++    *r = x*u - yi*vi;
++    *i = x*vi + u*yi;
++}
++
++static void get_covariance(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    const int ts_offset_hfadj = 4;
++    int num_ts_ext;
++
++    /* Create an additional delay of ts_offset_hfadj QMF time slots */
++    for (int sb = 0; sb < ssch->sba; sb++) {
++        int ts_offset_prev = s->num_qmf_timeslots - ts_offset_hfadj;
++
++        av_assert2(ts_offset_hfadj <= FF_ARRAY_ELEMS(ssch->Q_low_ext[0]));
++        av_assert2(ts_offset_prev + ts_offset_hfadj <= FF_ARRAY_ELEMS(ssch->Q_low_prev[0]));
++        for (int ts = 0; ts < ts_offset_hfadj; ts++) {
++            ssch->Q_low_ext[0][ts][sb] = ssch->Q_low_prev[0][ts + ts_offset_prev][sb];
++            ssch->Q_low_ext[1][ts][sb] = ssch->Q_low_prev[1][ts + ts_offset_prev][sb];
++        }
++
++        av_assert2(s->num_qmf_timeslots + s->ts_offset_hfgen + ts_offset_hfadj <= FF_ARRAY_ELEMS(ssch->Q_low_ext[0]));
++        av_assert2(s->num_qmf_timeslots + s->ts_offset_hfgen <= FF_ARRAY_ELEMS(ssch->Q_low[0]));
++        for (int ts = 0; ts < s->num_qmf_timeslots + s->ts_offset_hfgen; ts++) {
++            ssch->Q_low_ext[0][ts + ts_offset_hfadj][sb] = ssch->Q_low[0][ts][sb];
++            ssch->Q_low_ext[1][ts + ts_offset_hfadj][sb] = ssch->Q_low[1][ts][sb];
++        }
++    }
++
++    num_ts_ext = s->num_qmf_timeslots + s->ts_offset_hfgen + ts_offset_hfadj;
++    /* Loop over QMF subbands */
++    for (int sb = 0; sb < ssch->sba; sb++) {
++        for (int i = 0; i < 3; i++) {
++            for (int j = 1; j < 3; j++) {
++                ssch->cov[sb][i][j][0] = 0;
++                ssch->cov[sb][i][j][1] = 0;
++                /* Loop over QMF time slots */
++                for (int ts = ts_offset_hfadj; ts < num_ts_ext; ts += 2) {
++                    float re, im;
++
++                    fcomplex_mul(&re, &im,
++                                 ssch->Q_low_ext[0][ts - 2*i][sb],  ssch->Q_low_ext[1][ts - 2*i][sb],
++                                 ssch->Q_low_ext[0][ts - 2*j][sb], -ssch->Q_low_ext[1][ts - 2*j][sb]);
++
++                    ssch->cov[sb][i][j][0] += re;
++                    ssch->cov[sb][i][j][1] += im;
++                }
++            }
++        }
++    }
++}
++
++static float sqr(float a, float b)
++{
++    return a * a + b * b;
++}
++
++static void fcomplex_div(float *r, float *i, const float x, const float yi,
++                         const float u, const float vi)
++{
++    const float div = sqr(u, vi);
++    const float re = x*u + yi*vi;
++    const float im = x*vi - u*yi;
++    *r = re / div;
++    *i = im / div;
++}
++
++static void get_alphas(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    float EPSILON_INV = ldexpf(1.f, -20);
++
++    for (int sb = 0; sb < ssch->sba; sb++) {
++        float denom[2];
++
++        fcomplex_mul(&denom[0], &denom[1], ssch->cov[sb][2][2][0], ssch->cov[sb][2][2][1], ssch->cov[sb][1][1][0], ssch->cov[sb][1][1][1]);
++        denom[0] -= sqr(ssch->cov[sb][1][2][0], ssch->cov[sb][1][2][1]) / (1.f+EPSILON_INV);
++        if (sqr(denom[0], denom[1]) <= 1e-6f) {
++            ssch->alpha1[sb][0] = 0.f;
++            ssch->alpha1[sb][1] = 0.f;
++        } else {
++            float a, bi, c, di;
++
++            fcomplex_mul(&a, &bi, ssch->cov[sb][0][1][0], ssch->cov[sb][0][1][1],
++                                  ssch->cov[sb][1][2][0], ssch->cov[sb][1][2][1]);
++            fcomplex_mul(&c, &di, ssch->cov[sb][0][2][0], ssch->cov[sb][0][2][1],
++                                  ssch->cov[sb][1][1][0], ssch->cov[sb][1][1][1]);
++            ssch->alpha1[sb][0] = a - c;
++            ssch->alpha1[sb][1] = bi - di;
++            fcomplex_div(&ssch->alpha1[sb][0], &ssch->alpha1[sb][1], ssch->alpha1[sb][0], ssch->alpha1[sb][1], denom[0], denom[1]);
++        }
++
++        if (sqr(ssch->cov[sb][1][1][0], ssch->cov[sb][1][1][1]) <= 1e-6f) {
++            ssch->alpha0[sb][0] = 0.f;
++            ssch->alpha0[sb][1] = 0.f;
++        } else {
++            float a, bi;
++
++            fcomplex_mul(&a, &bi, ssch->alpha1[sb][0],     ssch->alpha1[sb][1],
++                                  ssch->cov[sb][1][2][0], -ssch->cov[sb][1][2][1]);
++
++            ssch->alpha0[sb][0]  = -ssch->cov[sb][0][1][0] + a;
++            ssch->alpha0[sb][1]  = -ssch->cov[sb][0][1][1] + bi;
++            fcomplex_div(&ssch->alpha0[sb][0], &ssch->alpha0[sb][1], ssch->alpha0[sb][0], ssch->alpha0[sb][1], ssch->cov[sb][1][1][0], ssch->cov[sb][1][1][1]);
++        }
++
++        if (sqr(ssch->alpha0[sb][0], ssch->alpha0[sb][1]) >= 16.f ||
++            sqr(ssch->alpha1[sb][0], ssch->alpha1[sb][1]) >= 16.f) {
++            ssch->alpha0[sb][0] = ssch->alpha0[sb][1] = 0.f;
++            ssch->alpha1[sb][0] = ssch->alpha1[sb][1] = 0.f;
++        }
++    }
++}
++
++static void create_high_signal(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    int ts_offset_hfadj = 4;
++    float m;
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->num_atsg_sig] * s->num_ts_in_ats; ts++) {
++        int sum_sb_patches = 0;
++        int g = 0;
++        /* Loop over number of patches */
++        for (int i = 0; i < ssch->num_sbg_patches; i++) {
++            /* Loop over number of subbands per patch */
++            for (int sb = 0; sb < ssch->sbg_patch_num_sb[i]; sb++) {
++                float cplx[2] = {0};
++                /* Map to High QMF Subband */
++                int n, p;
++                int sb_high = ssch->sbx + sum_sb_patches + sb;
++
++                /* Map to current noise envelope */
++                if (ssch->sbg_noise[g+1] == sb_high)
++                    g++;
++
++                n = ts + ts_offset_hfadj;
++                /* Current low QMF Subband */
++                p = ssch->sbg_patch_start_sb[i] + sb;
++
++                av_assert2(ts < FF_ARRAY_ELEMS(ssch->Q_high[0]));
++                av_assert2(sb_high < FF_ARRAY_ELEMS(ssch->Q_high[0][0]));
++
++                av_assert2(n < FF_ARRAY_ELEMS(ssch->Q_low_ext[0]));
++                av_assert2(p < FF_ARRAY_ELEMS(ssch->Q_low_ext[0][0]));
++
++                ssch->Q_high[0][ts][sb_high] = ssch->Q_low_ext[0][n][p];
++                ssch->Q_high[1][ts][sb_high] = ssch->Q_low_ext[1][n][p];
++
++                fcomplex_mul(&cplx[0], &cplx[1], ssch->alpha0[p][0], ssch->alpha0[p][1], ssch->Q_low_ext[0][n-2][p], ssch->Q_low_ext[1][n-2][p]);
++                ssch->Q_high[0][ts][sb_high] += cplx[0] * ssch->chirp_arr[g];
++                ssch->Q_high[1][ts][sb_high] += cplx[1] * ssch->chirp_arr[g];
++
++                fcomplex_mul(&cplx[0], &cplx[1], ssch->alpha1[p][0], ssch->alpha1[p][1], ssch->Q_low_ext[0][n-4][p], ssch->Q_low_ext[1][n-4][p]);
++                m = powf(ssch->chirp_arr[g], 2);
++                ssch->Q_high[0][ts][sb_high] += cplx[0] * m;
++                ssch->Q_high[1][ts][sb_high] += cplx[1] * m;
++
++                if (ss->aspx_preflat) {
++                    m = 1.f / ssch->gain_vec[p];
++                    ssch->Q_high[0][ts][sb_high] *= m;
++                    ssch->Q_high[1][ts][sb_high] *= m;
++                }
++            }
++            sum_sb_patches += ssch->sbg_patch_num_sb[i];
++        }
++    }
++}
++
++static void estimate_spectral_envelopes(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    const int ts_offset_hfadj = 4;
++
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over QMF subbands in A-SPX range */
++        for (int sb = 0, sbg = 0; sb < ssch->num_sb_aspx; sb++) {
++            float est_sig = 0.f;
++            int tsa, tsz;
++
++            av_assert2(sbg+1 < FF_ARRAY_ELEMS(ssch->sbg_sig[0]));
++            /* Update current subband group */
++            if (sb == ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg+1])
++                sbg++;
++
++            tsa = ssch->atsg_sig[atsg]*s->num_ts_in_ats + ts_offset_hfadj;
++            tsz = ssch->atsg_sig[atsg+1]*s->num_ts_in_ats + ts_offset_hfadj;
++            for (int ts = tsa; ts < tsz; ts++) {
++                if (ss->aspx_interpolation == 0) {
++                    for (int j = ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg]; j < ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg+1]; j++) {
++                        est_sig += sqr(ssch->Q_high[0][ts][j], ssch->Q_high[1][ts][j]);
++                    }
++                } else {
++                    est_sig += sqr(ssch->Q_high[0][ts][sb+ssch->sbx], ssch->Q_high[1][ts][sb+ssch->sbx]);
++                }
++            }
++
++            if (ss->aspx_interpolation == 0) {
++                est_sig /= ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg+1] - ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg];
++                est_sig /= ssch->atsg_sig[atsg+1] - ssch->atsg_sig[atsg];
++            } else {
++                est_sig /= ssch->atsg_sig[atsg+1] - ssch->atsg_sig[atsg];
++            }
++            ssch->est_sig_sb[atsg][sb] = est_sig;
++        }
++    }
++}
++
++static void map_signoise(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    int atsg_noise = 0;
++
++    memset(ssch->scf_noise_sb, 0, sizeof(ssch->scf_noise_sb));
++    memset(ssch->scf_sig_sb, 0, sizeof(ssch->scf_sig_sb));
++
++    /* Loop over Signal Envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Map Signal Envelopes from subband groups to QMF subbands */
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[ssch->atsg_freqres[atsg]]; sbg++) {
++            for (int sb = ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg]-ssch->sbx; sb < ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg+1]-ssch->sbx; sb++)
++                ssch->scf_sig_sb[atsg][sb] = ssch->scf_sig_sbg[atsg][sbg];
++        }
++
++        if (ssch->atsg_sig[atsg] == ssch->atsg_noise[atsg_noise + 1])
++            atsg_noise++;
++
++        av_assert2(atsg_noise < FF_ARRAY_ELEMS(ssch->scf_noise_sbg));
++        /* Map Noise Floors from subband groups to QMF subbands, and to signal envelopes */
++        for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++) {
++            for (int sb = ssch->sbg_noise[sbg] - ssch->sbx; sb < ssch->sbg_noise[sbg + 1] - ssch->sbx; sb++)
++                ssch->scf_noise_sb[atsg][sb] = ssch->scf_noise_sbg[atsg_noise][sbg];
++        }
++    }
++}
++
++static void add_sinusoids(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    float EPSILON = 1.0f;
++    float LIM_GAIN = 1.41254f;
++    float EPSILON0 = powf(10.f, -12.f);
++    float MAX_SIG_GAIN = powf(10.f, 5.f);
++    float MAX_BOOST_FACT = 1.584893192f;
++    int p_sine_at_end;
++
++    if (ssch->aspx_tsg_ptr_prev == ssch->num_atsg_sig_prev)
++        p_sine_at_end = 0;
++    else
++        p_sine_at_end = -1;
++
++    memcpy(ssch->sine_idx_sb_prev, ssch->sine_idx_sb, sizeof(ssch->sine_idx_sb));
++    memset(ssch->sine_idx_sb, 0, sizeof(ssch->sine_idx_sb));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over high resolution signal envelope subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_sig_highres; sbg++) {
++            int sba = ssch->sbg_sig_highres[sbg] - ssch->sbx;
++            int sbz = ssch->sbg_sig_highres[sbg+1] - ssch->sbx;
++            int sb_mid = (int)0.5f*(sbz + sba);
++            /* Map sinusoid markers to QMF subbands */
++            for (int sb = ssch->sbg_sig_highres[sbg]-ssch->sbx; sb < ssch->sbg_sig_highres[sbg+1]-ssch->sbx; sb++) {
++                if ((sb == sb_mid) && ((atsg >= ssch->aspx_tsg_ptr) || (p_sine_at_end == 0)
++                                       || ssch->sine_idx_sb_prev[ssch->num_atsg_sig_prev-1][sb])) {
++                    ssch->sine_idx_sb[atsg][sb] = ssch->aspx_add_harmonic[sbg];
++                }
++            }
++        }
++    }
++
++    memset(ssch->sine_area_sb, 0, sizeof(ssch->sine_area_sb));
++
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[ssch->atsg_freqres[atsg]]; sbg++) {
++            int sine_present = 0;
++            /* Additional sinusoid present in SF band? */
++            for (int sb = ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg]-ssch->sbx; sb < ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg+1]-ssch->sbx; sb++) {
++                if (ssch->sine_idx_sb[atsg][sb] == 1)
++                    sine_present = 1;
++            }
++
++            /* Mark all subbands in current subband group accordingly */
++            for (int sb = ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg]-ssch->sbx; sb < ssch->sbg_sig[ssch->atsg_freqres[atsg]][sbg+1]-ssch->sbx; sb++) {
++                ssch->sine_area_sb[atsg][sb] = sine_present;
++            }
++        }
++    }
++
++    memset(ssch->sine_lev_sb, 0, sizeof(ssch->sine_lev_sb));
++    memset(ssch->noise_lev_sb, 0, sizeof(ssch->noise_lev_sb));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over QMF subbands in A-SPX range */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            const float sig_noise_fact = ssch->scf_sig_sb[atsg][sb] / (1.f + ssch->scf_noise_sb[atsg][sb]);
++
++            ssch->sine_lev_sb[atsg][sb]  = sqrtf(ssch->sine_idx_sb[atsg][sb] * sig_noise_fact);
++            ssch->noise_lev_sb[atsg][sb] = sqrtf(ssch->scf_sig_sb[atsg][sb]);
++        }
++    }
++
++    memset(ssch->sig_gain_sb, 0, sizeof(ssch->sig_gain_sb));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over QMF subbands in A-SPX range */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            if (ssch->sine_area_sb[atsg][sb] == 0) {
++                float denom = EPSILON + ssch->est_sig_sb[atsg][sb];
++
++                if (!(atsg == ssch->aspx_tsg_ptr || atsg == p_sine_at_end))
++                    denom *= 1.f + ssch->scf_noise_sb[atsg][sb];
++                ssch->sig_gain_sb[atsg][sb] = sqrtf(ssch->scf_sig_sb[atsg][sb] / denom);
++            } else {
++                float denom = EPSILON + ssch->est_sig_sb[atsg][sb];
++
++                denom *= 1.f + ssch->scf_noise_sb[atsg][sb];
++                ssch->sig_gain_sb[atsg][sb] = sqrtf(ssch->scf_sig_sb[atsg][sb] * ssch->scf_noise_sb[atsg][sb] / denom);
++            }
++        }
++    }
++
++    memset(ssch->max_sig_gain_sbg, 0, sizeof(ssch->max_sig_gain_sbg));
++    memset(ssch->max_sig_gain_sb, 0, sizeof(ssch->max_sig_gain_sb));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over limiter subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_lim; sbg++) {
++            float denom = EPSILON0, nom = 0.f;
++
++            for (int sb = ssch->sbg_lim[sbg]-ssch->sbx; sb < ssch->sbg_lim[sbg+1]-1-ssch->sbx; sb++) {
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->scf_sig_sb[0]));
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->est_sig_sb[0]));
++                av_assert2(sb >= 0);
++                nom += ssch->scf_sig_sb[atsg][sb];
++                denom += ssch->est_sig_sb[atsg][sb];
++            }
++
++            ssch->max_sig_gain_sbg[atsg][sbg] = sqrtf(nom/denom) * LIM_GAIN;
++        }
++
++        /* Map to QMF subbands */
++        for (int sb = 0, sbg = 0; sb < ssch->num_sb_aspx; sb++) {
++            if (sb == ssch->sbg_lim[sbg+1]-ssch->sbx)
++                sbg++;
++            ssch->max_sig_gain_sb[atsg][sb] = fminf(ssch->max_sig_gain_sbg[atsg][sbg], MAX_SIG_GAIN);
++        }
++    }
++
++    memset(ssch->noise_lev_sb_lim, 0, sizeof(ssch->noise_lev_sb_lim));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            float tmp = ssch->noise_lev_sb[atsg][sb];
++
++            tmp *= ssch->max_sig_gain_sb[atsg][sb] / ssch->sig_gain_sb[atsg][sb];
++            ssch->noise_lev_sb_lim[atsg][sb] = fminf(ssch->noise_lev_sb[atsg][sb], tmp);
++        }
++    }
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            ssch->sig_gain_sb_lim[atsg][sb] = fminf(ssch->sig_gain_sb[atsg][sb],
++                                                    ssch->max_sig_gain_sb[atsg][sb]);
++        }
++    }
++
++    memset(ssch->boost_fact_sbg, 0, sizeof(ssch->boost_fact_sbg));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over limiter subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_lim; sbg++) {
++            float denom = EPSILON0, nom = 0.f;
++
++            /* Loop over subbands */
++            for (int sb = ssch->sbg_lim[sbg]-ssch->sbx; sb < ssch->sbg_lim[sbg+1]-1-ssch->sbx; sb++) {
++                av_assert2(sb >= 0);
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->scf_sig_sb[0]));
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->est_sig_sb[0]));
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->sig_gain_sb_lim[0]));
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->sine_lev_sb[0]));
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->noise_lev_sb_lim[0]));
++                av_assert2(sb < FF_ARRAY_ELEMS(ssch->boost_fact_sbg[0]));
++
++                nom   += ssch->scf_sig_sb[atsg][sb];
++                denom += ssch->est_sig_sb[atsg][sb] * powf(ssch->sig_gain_sb_lim[atsg][sb], 2);
++                denom += powf(ssch->sine_lev_sb[atsg][sb], 2);
++                if (!((ssch->sine_lev_sb[atsg][sb] != 0)
++                      || (atsg == ssch->aspx_tsg_ptr) || (atsg == p_sine_at_end)))
++                    denom += powf(ssch->noise_lev_sb_lim[atsg][sb], 2);
++            }
++            ssch->boost_fact_sbg[atsg][sbg] = sqrtf(nom/denom);
++        }
++    }
++
++    memset(ssch->boost_fact_sb, 0, sizeof(ssch->boost_fact_sb));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        int sbg = 0;
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            if (sb == ssch->sbg_lim[sbg+1]-ssch->sbx)
++                sbg++;
++            ssch->boost_fact_sb[atsg][sb] = fminf(ssch->boost_fact_sbg[atsg][sbg], MAX_BOOST_FACT);
++        }
++    }
++
++    memset(ssch->noise_lev_sb_adj, 0, sizeof(ssch->noise_lev_sb_adj));
++    memset(ssch->sine_lev_sb_adj, 0, sizeof(ssch->sine_lev_sb_adj));
++    memset(ssch->sig_gain_sb_adj, 0, sizeof(ssch->sig_gain_sb_adj));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->num_atsg_sig; atsg++) {
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            const float boost_fact           = ssch->boost_fact_sb[atsg][sb];
++            ssch->sig_gain_sb_adj[atsg][sb]  = ssch->sig_gain_sb_lim[atsg][sb] * boost_fact;
++            ssch->noise_lev_sb_adj[atsg][sb] = ssch->noise_lev_sb_lim[atsg][sb] * boost_fact;
++            ssch->sine_lev_sb_adj[atsg][sb]  = ssch->sine_lev_sb[atsg][sb] * boost_fact;
++        }
++    }
++}
++
++static int sine_idx(int sb, int ts, AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int index;
++
++    if (s->first_frame) {
++        index = 1;
++    } else {
++        index = (ssch->sine_idx_prev[ts][sb] + 1) & 3;
++    }
++    index += ts - ssch->atsg_sig[0];
++
++    return index & 3;
++}
++
++static int noise_idx(int sb, int ts, Substream *ss, SubstreamChannel *ssch)
++{
++    int index;
++
++    if (ssch->master_reset) {
++        index = 0;
++    } else {
++        index = ssch->noise_idx_prev[ts][sb];
++    }
++    index += ssch->num_sb_aspx * (ts - ssch->atsg_sig[0]);
++    index += sb + 1;
++
++    return index & 511;
++}
++
++static void generate_noise(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++
++    memset(ssch->qmf_noise, 0, sizeof(ssch->qmf_noise));
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats, atsg = 0;
++         ts < ssch->atsg_sig[ssch->num_atsg_sig] * s->num_ts_in_ats; ts++) {
++        if (ts == ssch->atsg_sig[atsg+1] * s->num_ts_in_ats)
++            atsg++;
++        /* Loop over QMF subbands in A-SPX */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            int idx;
++
++            av_assert2(ts < FF_ARRAY_ELEMS(ssch->noise_idx_prev));
++            av_assert2(sb < FF_ARRAY_ELEMS(ssch->noise_idx_prev[0]));
++
++            av_assert2(ts < FF_ARRAY_ELEMS(ssch->qmf_noise[0]));
++            av_assert2(sb < FF_ARRAY_ELEMS(ssch->qmf_noise[0][0]));
++
++            ssch->noise_idx_prev[ts][sb] = idx = noise_idx(sb, ts, ss, ssch);
++
++            ssch->qmf_noise[0][ts][sb] = ssch->noise_lev_sb_adj[atsg][sb] * aspx_noise[idx][0];
++            ssch->qmf_noise[1][ts][sb] = ssch->noise_lev_sb_adj[atsg][sb] * aspx_noise[idx][1];
++        }
++    }
++}
++
++static void generate_tones(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++
++    memset(ssch->qmf_sine, 0, sizeof(ssch->qmf_sine));
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats, atsg = 0;
++         ts < ssch->atsg_sig[ssch->num_atsg_sig] * s->num_ts_in_ats; ts++) {
++        if (ts == ssch->atsg_sig[atsg+1] * s->num_ts_in_ats)
++            atsg++;
++
++        /* Loop over QMF subbands in A-SPX */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            int idx;
++
++            av_assert2(ts < FF_ARRAY_ELEMS(ssch->sine_idx_prev));
++            av_assert2(sb < FF_ARRAY_ELEMS(ssch->sine_idx_prev[0]));
++
++            av_assert2(ts < FF_ARRAY_ELEMS(ssch->qmf_sine[0]));
++            av_assert2(sb < FF_ARRAY_ELEMS(ssch->qmf_sine[0][0]));
++
++            av_assert2(atsg < FF_ARRAY_ELEMS(ssch->sine_lev_sb_adj));
++            av_assert2(sb < FF_ARRAY_ELEMS(ssch->sine_lev_sb_adj[0]));
++
++            ssch->sine_idx_prev[ts][sb] = idx = sine_idx(sb, ts, s, ssch);
++
++            ssch->qmf_sine[0][ts][sb]  = ssch->sine_lev_sb_adj[atsg][sb];
++            ssch->qmf_sine[0][ts][sb] *= aspx_sine[0][idx];
++            ssch->qmf_sine[1][ts][sb]  = ssch->sine_lev_sb_adj[atsg][sb] * powf(-1, sb + ssch->sbx);
++            ssch->qmf_sine[1][ts][sb] *= aspx_sine[1][idx];
++        }
++    }
++}
++
++static void assemble_hf_signal(AC4DecodeContext *s, Substream *ss, int ch_id)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch_id];
++    const int sbx = ssch->sbx;
++    const int ts_offset_hfadj = 4;
++
++    memcpy(ssch->Y_prev, ssch->Y, sizeof(ssch->Y));
++    memset(ssch->Y, 0, sizeof(ssch->Y));
++
++    /* Get delayed QMF subsamples from delay buffer */
++    for (int ts = 0; ts < ssch->atsg_sig[0] * s->num_ts_in_ats; ts++) {
++        av_assert2(ts < FF_ARRAY_ELEMS(ssch->Y[0]));
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            av_assert2(ts < FF_ARRAY_ELEMS(ssch->Y_prev[0]));
++            av_assert2(ts < FF_ARRAY_ELEMS(ssch->Y[0]));
++            av_assert2(sb < FF_ARRAY_ELEMS(ssch->Y[0][0]));
++
++            ssch->Y[0][ts][sb] = ssch->Y_prev[0][ts][sb];
++            ssch->Y[1][ts][sb] = ssch->Y_prev[1][ts][sb];
++        }
++    }
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats, atsg = 0;
++         ts < ssch->atsg_sig[ssch->num_atsg_sig] * s->num_ts_in_ats; ts++) {
++        if (ts == ssch->atsg_sig[atsg+1] * s->num_ts_in_ats)
++            atsg++;
++        av_assert2(ts < FF_ARRAY_ELEMS(ssch->Y[0]));
++        av_assert2(ts + ts_offset_hfadj < FF_ARRAY_ELEMS(ssch->Q_high[0]));
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            ssch->Y[1][ts][sb] = ssch->Y[0][ts][sb] = ssch->sig_gain_sb_adj[atsg][sb];
++            fcomplex_mul(&ssch->Y[0][ts][sb], &ssch->Y[1][ts][sb],
++                         ssch->Y[0][ts][sb], ssch->Y[1][ts][sb],
++                         ssch->Q_high[0][ts + ts_offset_hfadj][sb + sbx],
++                         ssch->Q_high[1][ts + ts_offset_hfadj][sb + sbx]);
++        }
++    }
++
++    /* Loop over time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->num_atsg_sig] * s->num_ts_in_ats; ts++) {
++        av_assert2(ts < FF_ARRAY_ELEMS(ssch->Y[0]));
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            ssch->Y[0][ts][sb] += ssch->qmf_sine[0][ts][sb];
++            ssch->Y[1][ts][sb] += ssch->qmf_sine[1][ts][sb];
++            ssch->Y[0][ts][sb] += ssch->qmf_noise[0][ts][sb];
++            ssch->Y[1][ts][sb] += ssch->qmf_noise[1][ts][sb];
++        }
++    }
++
++    memcpy(ssch->Q_prev, ssch->Q, sizeof(ssch->Q));
++
++    for (int ts = 0; ts < ssch->atsg_sig[ssch->num_atsg_sig] * s->num_ts_in_ats; ts++) {
++        av_assert2(ts < FF_ARRAY_ELEMS(ssch->Y[0]));
++        av_assert2(ssch->num_sb_aspx + sbx <= MAX_QMF_BANDS);
++        av_assert2(ts / s->num_ts_in_ats < FF_ARRAY_ELEMS(ssch->aspx_tic_used_in_slot));
++        /* Loop over QMF subbands */
++
++        if (ssch->aspx_tic_used_in_slot[ts / s->num_ts_in_ats]) {
++            for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++                ssch->Q[0][ts][sbx+sb] = ssch->Q_prev[0][ts][sbx+sb];
++                ssch->Q[1][ts][sbx+sb] = ssch->Q_prev[1][ts][sbx+sb];
++            }
++        } else {
++            for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++                ssch->Q[0][ts][sbx+sb] = ssch->Q_prev[0][ts][sbx+sb];
++                ssch->Q[1][ts][sbx+sb] = ssch->Q_prev[1][ts][sbx+sb];
++
++                ssch->Q[0][ts][sbx+sb] += ssch->Y_prev[0][ts][sb] / 32768.f;
++                ssch->Q[1][ts][sbx+sb] += ssch->Y_prev[1][ts][sb] / 32768.f;
++            }
++        }
++    }
++}
++
++static int channels_aspx_processing(AC4DecodeContext *s, Substream *ss, int nb_ch)
++{
++    if (s->substream.codec_mode < CM_ASPX)
++        return 0;
++
++    for (int ch = 0; ch < nb_ch; ch++)
++        aspx_processing(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        get_qsignal_scale_factors(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        get_qnoise_scale_factors(s, ss, ch);
++
++    for (int ch = 0; ch < nb_ch; ch++) {
++        if (ss->ssch[ch].aspx_balance == 0)
++            mono_deq_signal_factors(s, ss, ch);
++    }
++
++    for (int ch = 0; ch < nb_ch; ch++) {
++        if (ss->ssch[ch].aspx_balance == 0)
++            mono_deq_noise_factors(s, ss, ch);
++    }
++
++    for (int ch = 0; ch < nb_ch; ch++) {
++        if (ss->ssch[ch].aspx_balance) {
++            joint_deq_signoise_factors(s, ss, (uint8_t[]){ch, ch+1});
++            ch++;
++        }
++    }
++
++    for (int ch = 0; ch < nb_ch; ch++)
++        preflattening(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        get_covariance(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        get_alphas(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        get_chirps(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        create_high_signal(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        estimate_spectral_envelopes(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        map_signoise(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        add_sinusoids(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        generate_tones(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        generate_noise(s, ss, ch);
++    for (int ch = 0; ch < nb_ch; ch++)
++        assemble_hf_signal(s, ss, ch);
++
++    return 0;
++}
++
++static void channel_companding(AC4DecodeContext *s, Substream *ss, int ch)
++{
++    SubstreamChannel *ssch = &ss->ssch[ch];
++    const int ts1 = ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats;
++    const int ts0 = ssch->atsg_sig[0] * s->num_ts_in_ats;
++    const int sb0 = 0, sb1 = ssch->sbx;
++    const int K = sb1 - sb0;
++    const int D = ts1 - ts0;
++    const float a = 0.65f;
++    const float G = powf(0.5f, -1.f / a);
++
++    for (int ts = ts0; ts < ts1; ts++) {
++        float sum = 0.f;
++
++        for (int sb = sb0; sb < sb1; sb++) {
++            float re = fabsf(ssch->Q[0][ts][sb]);
++            float im = fabsf(ssch->Q[1][ts][sb]);
++
++            ssch->E[ts][sb] = fmaxf(re, im) + 0.5f * fminf(re, im);
++            sum += ssch->E[ts][sb];
++        }
++
++        ssch->L[ts] = sum * 0.9105f / K;
++        ssch->g[ts] = powf(ssch->L[ts], (1.f - a) / a);
++        ss->g_sum[ts] += ssch->g[ts];
++    }
++
++    if (ss->sync_flag == 0) {
++        if (ss->compand_on[ch]) {
++            for (int ts = ts0; ts < ts1; ts++) {
++                const float factor = G * ssch->g[ts];
++
++                for (int sb = sb0; sb < sb1; sb++) {
++                    ssch->Q[0][ts][sb] *= factor;
++                    ssch->Q[1][ts][sb] *= factor;
++                }
++            }
++        } else if (ss->compand_avg) {
++            float sum = 0.f;
++            float factor;
++
++            for (int ts = ts0; ts < ts1; ts++)
++                sum += ssch->L[ts];
++
++            factor = G * powf(sum / D, (1.f - a) / a);
++
++            for (int ts = ts0; ts < ts1; ts++) {
++                for (int sb = sb0; sb < sb1; sb++) {
++                    ssch->Q[0][ts][sb] *= factor;
++                    ssch->Q[1][ts][sb] *= factor;
++                }
++            }
++        }
++    }
++}
++
++static void channels_companding(AC4DecodeContext *s, Substream *ss, int nb_ch)
++{
++    if (s->substream.codec_mode < CM_ASPX)
++        return;
++
++    memset(ss->g_sum, 0, sizeof(ss->g_sum));
++
++    for (int ch = 0; ch < nb_ch; ch++)
++        channel_companding(s, ss, ch);
++
++    if (ss->sync_flag) {
++        const float a = 0.65f;
++        const float G = powf(0.5f, -1.f / a);
++
++        for (int ch = 0; ch < nb_ch; ch++) {
++            SubstreamChannel *ssch = &ss->ssch[ch];
++            const int ts1 = ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats;
++            const int ts0 = ssch->atsg_sig[0] * s->num_ts_in_ats;
++            const int sb0 = 0, sb1 = ssch->sbx;
++
++            if (ss->compand_on[ch]) {
++                for (int ts = ts0; ts < ts1; ts++) {
++                    float factor = G * ss->g_sum[ts] / nb_ch;
++
++                    for (int sb = sb0; sb < sb1; sb++) {
++                        ssch->Q[0][ts][sb] *= factor;
++                        ssch->Q[1][ts][sb] *= factor;
++                    }
++                }
++            } else if (ss->compand_avg) {
++                const int D = ts1 - ts0;
++                float factor = 0.f;
++
++                for (int ts = ts0; ts < ts1; ts++)
++                    factor += ss->g_sum[ts] / nb_ch;
++                factor /= D;
++                factor *= G;
++
++                for (int ts = ts0; ts < ts1; ts++) {
++                    for (int sb = sb0; sb < sb1; sb++) {
++                        ssch->Q[0][ts][sb] *= factor;
++                        ssch->Q[1][ts][sb] *= factor;
++                    }
++                }
++            }
++        }
++    }
++}
++
++static void decode_channel(AC4DecodeContext *s, int ch, float *pcm)
++{
++    Substream *ss = &s->substream;
++    SubstreamChannel *ssch = &ss->ssch[ch];
++
++    qmf_synthesis(s, ssch, pcm);
++}
++
++static int ac4_decode_frame(AVCodecContext *avctx, AVFrame *frame,
++                            int *got_frame_ptr, AVPacket *avpkt)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++    GetBitContext *gb = &s->gbc;
++    int ret, start_offset = 0;
++    SubstreamInfo *ssinfo;
++    int presentation;
++    uint32_t header;
++
++    if (avpkt->size < 8) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid packet size: %d\n", avpkt->size);
++        ret = AVERROR_INVALIDDATA;
++        goto error;
++    }
++
++    header = AV_RB16(avpkt->data);
++    if (header == 0xAC40 || header == 0xAC41) {
++        int size = AV_RB16(avpkt->data + 2);
++
++        start_offset = 4;
++        if (size == 0xFFFF)
++            start_offset += 3;
++    }
++
++    if ((ret = init_get_bits8(gb, avpkt->data, avpkt->size)) < 0)
++        goto error;
++    av_log(s->avctx, AV_LOG_DEBUG, "packet_size: %d\n", avpkt->size);
++    skip_bits_long(gb, start_offset * 8);
++
++    ret = ac4_toc(s);
++    if (ret < 0)
++        goto error;
++
++    if (!s->have_iframe)
++        return avpkt->size;
++
++    if (s->version == 2 && !s->ssgroup[0].channel_coded) {
++        avpriv_report_missing_feature(s->avctx, "object coding");
++        ret = AVERROR_PATCHWELCOME;
++        goto error;
++    }
++
++    presentation = FFMIN(s->target_presentation, FFMAX(0, s->nb_presentations - 1));
++    ssinfo = s->version == 2 ? &s->ssgroup[0].ssinfo : &s->pinfo[presentation].ssinfo[0];
++    avctx->sample_rate = s->fs_index ? 48000 : 44100;
++
++    if (ssinfo->channel_mode >= FF_ARRAY_ELEMS(channel_mode_layouts)) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid channel mode: %d\n", ssinfo->channel_mode);
++        ret = AVERROR_INVALIDDATA;
++        goto error;
++    }
++
++    av_channel_layout_copy(&avctx->ch_layout, &channel_mode_layouts[ssinfo->channel_mode]);
++    avctx->sample_rate = av_rescale(avctx->sample_rate,
++                                    s->resampling_ratio.den,
++                                    s->resampling_ratio.num);
++    frame->nb_samples = s->frame_len_base;
++
++    skip_bits_long(gb, s->payload_base * 8);
++
++    for (int i = 0; i < s->nb_substreams; i++) {
++        int substream_type = s->substream_type[i];
++
++        switch (substream_type) {
++        case ST_SUBSTREAM:
++            ret = ac4_substream(s, &s->ssgroup[0], ssinfo, s->substream_size[i]);
++            break;
++        case ST_PRESENTATION:
++            skip_bits_long(gb, s->substream_size[i] * 8);
++            break;
++        default:
++            av_assert0(0);
++        }
++
++        if (ret < 0)
++            goto error;
++
++        if (substream_type == ST_SUBSTREAM)
++            break;
++    }
++
++    if (get_bits_left(gb) < 0)
++        av_log(s->avctx, AV_LOG_WARNING, "overread\n");
++
++    for (int ch = 0; ch < avctx->ch_layout.nb_channels; ch++)
++        scale_spec(s, ch);
++
++    switch (ssinfo->channel_mode) {
++    case 0:
++        /* nothing to do */
++        break;
++    case 1:
++        stereo_processing(s, &s->substream);
++        break;
++    case 3:
++    case 4:
++        m5channel_processing(s, &s->substream);
++        break;
++    }
++
++    for (int ch = 0; ch < avctx->ch_layout.nb_channels; ch++)
++        prepare_channel(s, ch);
++
++    channels_companding(s, &s->substream, avctx->ch_layout.nb_channels);
++
++    ret = channels_aspx_processing(s, &s->substream, avctx->ch_layout.nb_channels);
++    if (ret < 0)
++        goto error;
++
++    if (get_bits_left(gb) > 0)
++        av_log(s->avctx, AV_LOG_DEBUG, "underread %d\n", get_bits_left(gb));
++
++    if ((ret = ff_get_buffer(avctx, frame, 0)) < 0)
++        return ret;
++
++    for (int ch = 0; ch < avctx->ch_layout.nb_channels; ch++) {
++        const int sch = av_channel_layout_channel_from_index(&avctx->ch_layout, ch);
++        const int dch = s->ch_map[sch];
++
++        decode_channel(s, dch, (float *)frame->extended_data[ch]);
++    }
++
++    if (s->iframe_global)
++        frame->flags |= AV_FRAME_FLAG_KEY;
++
++    s->first_frame = 0;
++
++    *got_frame_ptr = 1;
++
++    return avpkt->size;
++
++error:
++    s->have_iframe = 0;
++
++    *got_frame_ptr = 0;
++
++    return ret;
++}
++
++static av_cold void ac4_flush(AVCodecContext *avctx)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++
++    s->have_iframe = 0;
++    s->sequence_counter_prev = 0;
++}
++
++static av_cold int ac4_decode_end(AVCodecContext *avctx)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++
++    av_freep(&s->fdsp);
++
++    for (int j = 0; j < 8; j++)
++        for (int i = 0; i < 5; i++)
++            av_tx_uninit(&s->tx_ctx[j][i]);
++
++    return 0;
++}
++
++#define OFFSET(param) offsetof(AC4DecodeContext, param)
++#define FLAGS AV_OPT_FLAG_DECODING_PARAM | AV_OPT_FLAG_AUDIO_PARAM
++
++static const AVOption options[] = {
++    { "presentation", "select presentation", OFFSET(target_presentation), AV_OPT_TYPE_INT, {.i64=0}, 0, INT_MAX, FLAGS },
++    { NULL},
++};
++
++static const AVClass ac4_decoder_class = {
++    .class_name = "AC4 decoder",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++const FFCodec ff_ac4_decoder = {
++    .p.name         = "ac4",
++    CODEC_LONG_NAME("AC-4"),
++    .p.type         = AVMEDIA_TYPE_AUDIO,
++    .p.id           = AV_CODEC_ID_AC4,
++    .p.priv_class   = &ac4_decoder_class,
++    .priv_data_size = sizeof(AC4DecodeContext),
++    .init           = ac4_decode_init,
++    .close          = ac4_decode_end,
++    FF_CODEC_DECODE_CB(ac4_decode_frame),
++    .flush          = ac4_flush,
++    .p.capabilities = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_CHANNEL_CONF,
++    .caps_internal  = FF_CODEC_CAP_INIT_CLEANUP,
++};
+diff --git a/libavcodec/ac4dec_data.h b/libavcodec/ac4dec_data.h
+new file mode 100644
+index 0000000000..1eb24b22f2
+--- /dev/null
++++ b/libavcodec/ac4dec_data.h
+@@ -0,0 +1,1688 @@
++/*
++ * AC-4 Audio Decoder
++ *
++ * This file is part of Librempeg
++ *
++ * Librempeg is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * Librempeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along
++ * with Librempeg; if not, write to the Free Software Foundation, Inc.,
++ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++
++#ifndef AVCODEC_AC4DEC_DATA_H
++#define AVCODEC_AC4DEC_DATA_H
++
++#include <stdint.h>
++#include <libavutil/mem.h>
++
++static const AVRational resampling_ratios[] = {
++    {25025, 24000},
++    {25, 24},
++    {15, 16},
++    {25025, 24000},
++    {25, 24},
++    {25025, 24000},
++    {25, 24},
++    {15, 16},
++    {25025, 24000},
++    {25, 24},
++    {15, 16},
++    {25025, 24000},
++    {25, 24},
++    {1, 1},
++    {1, 1},
++    {1, 1},
++};
++
++static const uint8_t aspx_hcb_env_level_15_f0_bits[71] = {
++     7,  9,  9,  9,  9,  8,  8,  7,  7,  7,  7,  7,  6,  6,  6,  6,
++     6,  6,  6,  6,  6,  6,  5,  5,  5,  5,  5,  5,  5,  5,  4,  5,
++     5,  5,  5,  5,  5,  5,  4,  5,  5,  5,  5,  6,  6,  6,  7,  8,
++     9, 10, 11, 12, 14, 14, 16, 16, 17, 17, 18, 18, 18, 18, 18, 18,
++    18, 18, 17, 17, 17, 17, 16,
++};
++
++static const uint32_t aspx_hcb_env_level_15_f0_codes[71] = {
++    0x0003e, 0x0007e, 0x0007f, 0x000be, 0x000bf, 0x0003e, 0x0005e, 0x00016,
++    0x00017, 0x0001e, 0x0002e, 0x0005e, 0x00012, 0x0000a, 0x0000c, 0x0000e,
++    0x00013, 0x00016, 0x0001a, 0x0001b, 0x00022, 0x00023, 0x00004, 0x00008,
++    0x0000c, 0x0000e, 0x00012, 0x00014, 0x00015, 0x0001a, 0x00000, 0x00016,
++    0x00018, 0x0001e, 0x0001c, 0x00019, 0x0001d, 0x0001f, 0x00001, 0x0001b,
++    0x00013, 0x00010, 0x0000a, 0x0002e, 0x0001e, 0x0000d, 0x0003f, 0x000be,
++    0x0017e, 0x002fe, 0x005fe, 0x00bfe, 0x02ffe, 0x02ffc, 0x0bffc, 0x0bff6,
++    0x17ffa, 0x17ffb, 0x2fff8, 0x2fff9, 0x2fffa, 0x2fffb, 0x2fffc, 0x2fffd,
++    0x2fffe, 0x2ffff, 0x17fe8, 0x17fe9, 0x17fea, 0x17feb, 0x0bff7,
++};
++
++static const uint8_t aspx_hcb_env_level_15_df_bits[141] = {
++    21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
++    21, 21, 17, 18, 19, 19, 21, 19, 19, 19, 21, 20, 20, 20, 16, 17,
++    19, 19, 18, 18, 17, 15, 15, 15, 15, 14, 14, 14, 14, 13, 13, 13,
++    13, 13, 13, 13, 12, 12, 12, 12, 12, 11, 10, 10,  9,  8,  8,  7,
++     6,  6,  5,  4,  3,  2,  2,  3,  4,  6,  7,  7,  8,  9, 10, 11,
++    11, 12, 13, 13, 14, 14, 15, 15, 15, 16, 16, 16, 17, 17, 17, 17,
++    17, 18, 17, 17, 16, 17, 18, 19, 20, 21, 19, 19, 18, 16, 19, 21,
++    16, 20, 20, 21, 21, 20, 20, 19, 20, 19, 17, 21, 21, 21, 21, 21,
++    21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
++};
++
++static const uint32_t aspx_hcb_env_level_15_df_codes[141] = {
++    0xfeff2, 0xfeff3, 0xfeff4, 0xfeff5, 0xfeff6, 0xfeff7, 0xfeff8, 0xfeff9,
++    0xfeffa, 0xfeffb, 0xfeffc, 0xfeffd, 0xfeffe, 0xfefff, 0xff5e4, 0xff5e5,
++    0xff5e6, 0xff5e7, 0x0fef4, 0x1fefe, 0x3fdea, 0x3ffde, 0xff7b6, 0x3fdec,
++    0x3fdee, 0x3fd78, 0xff5ee, 0x7f798, 0x7faf6, 0x7f799, 0x07ffa, 0x0fef6,
++    0x3fdef, 0x3ffdf, 0x1fdee, 0x1ffee, 0x0ff7e, 0x03d7e, 0x03fba, 0x03fbe,
++    0x03ffe, 0x01ebe, 0x01fdc, 0x01fee, 0x01ff6, 0x00f5c, 0x00f5d, 0x00f7e,
++    0x00f7f, 0x00ff4, 0x00ff6, 0x00ffe, 0x007bc, 0x007bd, 0x007f6, 0x007fc,
++    0x007fe, 0x003fa, 0x001ea, 0x001fc, 0x000f6, 0x00076, 0x0007e, 0x0003c,
++    0x0001c, 0x0003e, 0x0001e, 0x0000e, 0x00006, 0x00002, 0x00000, 0x00002,
++    0x00006, 0x0003f, 0x0003e, 0x0003a, 0x00077, 0x000f4, 0x001ee, 0x003fc,
++    0x003d6, 0x007be, 0x00ffa, 0x00f5e, 0x01ff7, 0x01fea, 0x03ffc, 0x03fd6,
++    0x03fbb, 0x07fbe, 0x07fae, 0x07f7e, 0x0fff6, 0x0fffe, 0x0fef5, 0x0fef2,
++    0x0f5fe, 0x1fffe, 0x0ff78, 0x0fefe, 0x07afe, 0x0ff79, 0x1fef4, 0x3fd7a,
++    0x7f79a, 0xff5ef, 0x3fdfe, 0x3fffe, 0x1fdef, 0x07ffe, 0x3fdff, 0xff5f2,
++    0x07f78, 0x7f79b, 0x7f79e, 0xff5f3, 0xff5f4, 0x7f79f, 0x7faf8, 0x3ffff,
++    0x7f7f8, 0x3fbce, 0x0f5ff, 0xff5f5, 0xff5f6, 0xff5f7, 0xff5f8, 0xff5f9,
++    0xff5fa, 0xff5fb, 0xff5fc, 0xff5fd, 0xff5fe, 0xff5ff, 0xff7ac, 0xff7ad,
++    0xff7ae, 0xff7af, 0xff7b4, 0xff7b5, 0xff7b7,
++};
++
++static const uint8_t aspx_hcb_env_level_15_dt_bits[141] = {
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 18, 18, 18, 18, 18,
++    17, 19, 17, 16, 17, 17, 17, 16, 15, 16, 15, 15, 14, 14, 14, 13,
++    12, 10,  8,  6,  4,  2,  1,  3,  5,  7, 10, 11, 12, 14, 14, 15,
++    15, 16, 16, 17, 16, 17, 17, 18, 16, 17, 18, 18, 19, 18, 19, 19,
++    17, 18, 18, 19, 19, 19, 19, 19, 19, 19, 19, 19, 18, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++};
++
++static const uint32_t aspx_hcb_env_level_15_dt_codes[141] = {
++    0x7ffa0, 0x7ffa1, 0x7ffa2, 0x7ffa3, 0x7ffa4, 0x7ffa5, 0x7ffa6, 0x7ffa7,
++    0x7ffa8, 0x7ffa9, 0x7ffaa, 0x7ffab, 0x7ffac, 0x7ffad, 0x7ffae, 0x7ffaf,
++    0x7ffb0, 0x7ffb1, 0x7ffb2, 0x7ffb3, 0x7ffb4, 0x7ffb5, 0x7ffb6, 0x7ffb7,
++    0x7ffb8, 0x7ffb9, 0x7ffba, 0x7ffbb, 0x7ffbc, 0x7ffbd, 0x7ffbe, 0x7ffbf,
++    0x7ffc0, 0x7ffc1, 0x7ffc2, 0x7ffc3, 0x7ffc4, 0x7ffc5, 0x7ffc6, 0x7ffc7,
++    0x7ffcc, 0x7ffcd, 0x7ffce, 0x3ff16, 0x3ff17, 0x3ff1e, 0x3ff1f, 0x3ff3c,
++    0x1fefa, 0x7ffcf, 0x1ffb6, 0x0ff7c, 0x1ff8e, 0x1ffbe, 0x1fefb, 0x0ffc4,
++    0x07fba, 0x0ffc6, 0x07fbb, 0x07fee, 0x03fdc, 0x03ff0, 0x03ff2, 0x01ffa,
++    0x00ffe, 0x003fc, 0x000fe, 0x0003e, 0x0000e, 0x00002, 0x00000, 0x00006,
++    0x0001e, 0x0007e, 0x003fe, 0x007fa, 0x00ff6, 0x03ffc, 0x03fde, 0x07fe6,
++    0x07fec, 0x0ffda, 0x0ffde, 0x1fefe, 0x0ffce, 0x1fff2, 0x1ffbf, 0x3ff3d,
++    0x0ff7e, 0x1feff, 0x3ff3e, 0x3ff3f, 0x7ffd2, 0x3ffe8, 0x7ffd3, 0x7ffd4,
++    0x1ff8a, 0x3ff6e, 0x3ff6f, 0x7ffd5, 0x7ffd6, 0x7ffd7, 0x7ffd8, 0x7ffd9,
++    0x7ffda, 0x7ffdb, 0x7ffde, 0x7ffdf, 0x3ffee, 0x7ffe0, 0x7ffe1, 0x7ffe2,
++    0x7ffe3, 0x7ffe4, 0x7ffe5, 0x7ffe6, 0x7ffe7, 0x7ffe8, 0x7ffe9, 0x7ffea,
++    0x7ffeb, 0x7ffec, 0x7ffed, 0x7ffee, 0x7ffef, 0x7fff0, 0x7fff1, 0x7fff2,
++    0x7fff3, 0x7fff4, 0x7fff5, 0x7fff6, 0x7fff7, 0x7fff8, 0x7fff9, 0x7fffa,
++    0x7fffb, 0x7fffc, 0x7fffd, 0x7fffe, 0x7ffff,
++};
++
++static const uint8_t aspx_hcb_env_balance_15_f0_bits[25] = {
++    13, 16, 15, 15, 13, 12, 11,  9,  8,  7,  5,  3,  1,  2,  4,  7,
++     8,  9, 10, 10, 11, 12, 13, 15, 16,
++};
++
++static const uint32_t aspx_hcb_env_balance_15_f0_codes[25] = {
++    0x01ffe, 0x0ffea, 0x07ff6, 0x07ff7, 0x01fff, 0x00ffc, 0x007de, 0x001f6,
++    0x000fa, 0x0007c, 0x0001e, 0x00006, 0x00000, 0x00002, 0x0000e, 0x0007e,
++    0x000fe, 0x001fe, 0x003fe, 0x003ee, 0x007df, 0x00ffd, 0x01ffc, 0x07ff4,
++    0x0ffeb,
++};
++
++static const uint8_t aspx_hcb_env_balance_15_df_bits[49] = {
++    19, 19, 19, 19, 19, 18, 18, 17, 16, 16, 16, 15, 13, 13, 12, 12,
++    12, 11, 10,  9,  8,  7,  5,  3,  1,  2,  4,  7,  8, 10, 10, 11,
++    12, 12, 13, 13, 14, 15, 16, 18, 18, 17, 18, 18, 18, 19, 19, 18,
++    19,
++};
++
++static const uint32_t aspx_hcb_env_balance_15_df_codes[49] = {
++    0x7def6, 0x7def7, 0x7defa, 0x7defb, 0x7dffe, 0x3ef7c, 0x3ef7e, 0x1f7b2,
++    0x0fbd8, 0x0fbda, 0x0fbfe, 0x07dfe, 0x01f6e, 0x01f7a, 0x00f9e, 0x00fb6,
++    0x00fbc, 0x007da, 0x003ec, 0x001f2, 0x000fa, 0x0007e, 0x0001e, 0x00006,
++    0x00000, 0x00002, 0x0000e, 0x0007f, 0x000f8, 0x003ee, 0x003e6, 0x007ce,
++    0x00fbe, 0x00f9f, 0x01f7e, 0x01f6f, 0x03efe, 0x07dee, 0x0fbdb, 0x3ef78,
++    0x3ef7f, 0x1f7b3, 0x3effc, 0x3effd, 0x3ef79, 0x7dffc, 0x7dffd, 0x3ef7a,
++    0x7dfff,
++};
++
++static const uint8_t aspx_hcb_env_balance_15_dt_bits[49] = {
++    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 13, 13, 12, 12,
++    11, 12, 11,  9,  8,  7,  4,  2,  1,  3,  5,  7,  9,  9, 10, 11,
++    11, 12, 12, 12, 12, 13, 15, 14, 15, 14, 15, 15, 15, 14, 14, 15,
++    15,
++};
++
++static const uint32_t aspx_hcb_env_balance_15_dt_codes[49] = {
++    0x07dce, 0x07dcf, 0x07ddc, 0x07ddd, 0x07dde, 0x07ddf, 0x07dec, 0x07ded,
++    0x07dee, 0x07def, 0x07df8, 0x03ebe, 0x01f5e, 0x01f7a, 0x00fb8, 0x00fba,
++    0x007cc, 0x00fbe, 0x007d6, 0x001f2, 0x000f8, 0x0007e, 0x0000e, 0x00002,
++    0x00000, 0x00006, 0x0001e, 0x0007f, 0x001f6, 0x001f4, 0x003ea, 0x007cd,
++    0x007ce, 0x00f9e, 0x00fae, 0x00fbc, 0x00f9f, 0x01f76, 0x07df9, 0x03ebf,
++    0x07dfa, 0x03ee4, 0x07dfb, 0x07dfc, 0x07dfd, 0x03ee5, 0x03ee6, 0x07dfe,
++    0x07dff,
++};
++
++static const uint8_t aspx_hcb_env_level_30_f0_bits[36] = {
++    11, 13, 11, 11, 10, 10,  9,  8,  8,  7,  7,  7,  6,  6,  5,  5,
++     4,  4,  4,  4,  3,  3,  3,  3,  4,  5,  6,  7,  9, 12, 14, 16,
++    17, 16, 17, 16,
++};
++
++static const uint32_t aspx_hcb_env_level_30_f0_codes[36] = {
++    0x007fe, 0x01ffe, 0x001de, 0x001df, 0x000ee, 0x003fe, 0x001fe, 0x0003a,
++    0x000fe, 0x0001c, 0x0001e, 0x0007e, 0x0002e, 0x0003e, 0x00006, 0x00016,
++    0x00002, 0x0000a, 0x0000c, 0x0000e, 0x00002, 0x00003, 0x00004, 0x00000,
++    0x0000d, 0x0001e, 0x0002f, 0x0001f, 0x00076, 0x00ffe, 0x03ffe, 0x0fffc,
++    0x1fffe, 0x0fffe, 0x1ffff, 0x0fffd,
++};
++
++static const uint8_t aspx_hcb_env_level_30_df_bits[71] = {
++    23, 23, 23, 23, 22, 22, 22, 22, 20, 19, 19, 20, 19, 18, 17, 16,
++    16, 15, 14, 14, 14, 13, 13, 13, 13, 12, 12, 12, 11, 10,  9,  8,
++     5,  4,  2,  1,  3,  6,  8,  9, 11, 12, 14, 14, 15, 16, 17, 17,
++    17, 18, 18, 19, 21, 19, 17, 20, 19, 20, 20, 20, 19, 19, 19, 22,
++    22, 22, 22, 22, 22, 22, 22,
++};
++
++static const uint32_t aspx_hcb_env_level_30_df_codes[71] = {
++    0x7ffbfc, 0x7ffbfd, 0x7ffbfe, 0x7ffbff, 0x3f7f6c, 0x3f7f6d, 0x3f7f6e,
++    0x3f7f6f, 0x0fdfee, 0x07effe, 0x07efec, 0x0fff7e, 0x07ffbe, 0x03f7fe,
++    0x01fbfe, 0x00fdfc, 0x00fff6, 0x007ffa, 0x003f7e, 0x003ffc, 0x003ffe,
++    0x001fba, 0x001fbe, 0x001ffa, 0x001ffb, 0x000fdc, 0x000ffc, 0x000ffe,
++    0x0007fc, 0x0003f6, 0x0001fe, 0x0000fe, 0x00001e, 0x00000e, 0x000002,
++    0x000000, 0x000006, 0x00003e, 0x0000fc, 0x0001fa, 0x0007fd, 0x000fde,
++    0x003fff, 0x003f76, 0x007eee, 0x00fdde, 0x01ffee, 0x01fbfc, 0x01fbfa,
++    0x03ffde, 0x03f77e, 0x07efee, 0x1ffefe, 0x07eefe, 0x01fbbe, 0x0fdfea,
++    0x07eff6, 0x0fdfda, 0x0fdfde, 0x0fdfef, 0x07eff4, 0x07efff, 0x07eeff,
++    0x3f7fae, 0x3f7f7c, 0x3f7f7d, 0x3f7f7e, 0x3f7f7f, 0x3f7fac, 0x3f7fad,
++    0x3f7faf,
++};
++
++static const uint8_t aspx_hcb_env_level_30_dt_bits[71] = {
++    20, 20, 20, 20, 20, 20, 20, 20, 20, 19, 19, 20, 20, 18, 16, 16,
++    15, 16, 15, 14, 14, 14, 13, 13, 13, 12, 12, 11, 11, 10, 10,  8,
++     6,  4,  2,  1,  3,  5,  8,  9, 11, 11, 12, 13, 13, 14, 14, 14,
++    15, 15, 16, 17, 18, 19, 18, 18, 18, 18, 20, 19, 20, 20, 20, 20,
++    20, 20, 20, 20, 20, 20, 19,
++};
++
++static const uint32_t aspx_hcb_env_level_30_dt_codes[71] = {
++    0x0ff7d6, 0x0ff7d7, 0x0ff7d8, 0x0ff7d9, 0x0ff7da, 0x0ff7db, 0x0ff7dc,
++    0x0ff7dd, 0x0ff7de, 0x07fbfe, 0x07ed7a, 0x0ff7df, 0x0ff7f2, 0x03fdf4,
++    0x00ff7c, 0x00fdae, 0x007ede, 0x00ff7e, 0x007ed2, 0x003f68, 0x003f6e,
++    0x003ffa, 0x001fb6, 0x001ffe, 0x001fff, 0x000fde, 0x000ff6, 0x0007ec,
++    0x0007fa, 0x0003fc, 0x0003fe, 0x0000fc, 0x00003e, 0x00000e, 0x000002,
++    0x000000, 0x000006, 0x00001e, 0x0000fe, 0x0001fa, 0x0007fe, 0x0007ee,
++    0x000fdf, 0x001ffc, 0x001fee, 0x003ffb, 0x003fde, 0x003f6a, 0x007ed6,
++    0x007ed3, 0x00fdbe, 0x01fb7e, 0x03f6bc, 0x07fbf8, 0x03f6be, 0x03f6bf,
++    0x03f6fe, 0x03f6ff, 0x0ff7f3, 0x07fbea, 0x0ff7f4, 0x0ff7f5, 0x0ff7f6,
++    0x0ff7f7, 0x0ff7f8, 0x0ff7f9, 0x0ff7fa, 0x0ff7fb, 0x0ff7fe, 0x0ff7ff,
++    0x07ed7b,
++};
++
++static const uint8_t aspx_hcb_env_balance_30_f0_bits[13] = {
++    12, 11,  9,  7,  4,  3,  1,  2,  5,  6,  8, 10, 12,
++};
++
++static const uint16_t aspx_hcb_env_balance_30_f0_codes[13] = {
++    0x000ffe, 0x0007fe, 0x0001fe, 0x00007e, 0x00000e, 0x000006, 0x000000,
++    0x000002, 0x00001e, 0x00003e, 0x0000fe, 0x0003fe, 0x000fff,
++};
++
++static const uint8_t aspx_hcb_env_balance_30_df_bits[25] = {
++    17, 17, 17, 15, 14, 12,  9,  9,  8,  7,  5,  2,  1,  3,  4,  7,
++     8,  9, 10, 11, 14, 15, 16, 16, 17,
++};
++
++static const uint32_t aspx_hcb_env_balance_30_df_codes[25] = {
++    0x01fffc, 0x01fffd, 0x01fffe, 0x007ffa, 0x003ffc, 0x000ffe, 0x0001fc,
++    0x0001fe, 0x0000fa, 0x00007e, 0x00001e, 0x000002, 0x000000, 0x000006,
++    0x00000e, 0x00007c, 0x0000fb, 0x0001fd, 0x0003fe, 0x0007fe, 0x003ffe,
++    0x007ffb, 0x00fffc, 0x00fffd, 0x01ffff,
++};
++
++static const uint8_t aspx_hcb_env_balance_30_dt_bits[25] = {
++    15, 15, 15, 14, 13, 13, 10,  8,  8,  7,  4,  2,  1,  3,  5,  7,
++     9,  9,  9, 12, 14, 13, 14, 15, 14,
++};
++
++static const uint16_t aspx_hcb_env_balance_30_dt_codes[25] = {
++    0x007ff2, 0x007ff3, 0x007ff6, 0x003ff6, 0x001ffe, 0x001fff, 0x0003fe,
++    0x0000fa, 0x0000fe, 0x00007e, 0x00000e, 0x000002, 0x000000, 0x000006,
++    0x00001e, 0x00007c, 0x0001fe, 0x0001f6, 0x0001f7, 0x000ffc, 0x003ffa,
++    0x001ffa, 0x003ff7, 0x007ff7, 0x003ff8,
++};
++
++static const uint8_t aspx_hcb_noise_level_f0_bits[30] = {
++    12, 12,  9,  7,  6,  6,  5,  1,  2,  3,  5,  7,  8,  8,  9, 10,
++    11, 12, 12, 12, 13, 13, 14, 12, 14, 14, 11, 16, 16, 15,
++};
++
++static const uint16_t aspx_hcb_noise_level_f0_codes[30] = {
++    0x000efe, 0x000eff, 0x0001fe, 0x000076, 0x00003a, 0x00003e, 0x00001e,
++    0x000000, 0x000002, 0x000006, 0x00001c, 0x00007e, 0x0000fe, 0x0000ee,
++    0x0001ff, 0x0003bc, 0x00077c, 0x000efa, 0x000ef4, 0x000ef6, 0x001df6,
++    0x001dee, 0x003bee, 0x000ef5, 0x003bde, 0x003bef, 0x00077e, 0x00ef7e,
++    0x00ef7f, 0x0077be,
++};
++
++static const uint8_t aspx_hcb_noise_level_df_bits[59] = {
++    17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 13, 14, 16, 16, 15, 15,
++    16, 15, 14, 14, 14, 14, 13, 11, 10,  9,  8,  7,  3,  1,  2,  4,
++     5,  7,  8,  9, 10, 12, 13, 13, 14, 16, 17, 17, 17, 17, 17, 17,
++    16, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
++};
++
++static const uint32_t aspx_hcb_noise_level_df_codes[59] = {
++    0x01f19e, 0x01f19f, 0x01f1dc, 0x01f1dd, 0x01f1de, 0x01f1df, 0x01f1e8,
++    0x01f1e9, 0x01f1ea, 0x01f1eb, 0x001f1a, 0x003e7e, 0x00f9fe, 0x00f8f6,
++    0x007c76, 0x007c66, 0x00f8f7, 0x007c7c, 0x003e3c, 0x003e36, 0x003e37,
++    0x003e3a, 0x001f3e, 0x0007ce, 0x0003e6, 0x0001f0, 0x0000fa, 0x00007e,
++    0x000006, 0x000000, 0x000002, 0x00000e, 0x00001e, 0x00007f, 0x0000fb,
++    0x0001f2, 0x0003e2, 0x000f9e, 0x001f1c, 0x001f18, 0x003e32, 0x00f8fa,
++    0x01f3fe, 0x01f1f6, 0x01f1f7, 0x01f1f8, 0x01f1f9, 0x01f1fa, 0x00f8ce,
++    0x01f1fb, 0x01f1fc, 0x01f1fd, 0x01f1fe, 0x01f1ff, 0x01f3f8, 0x01f3f9,
++    0x01f3fa, 0x01f3fb, 0x01f3ff,
++};
++
++static const uint8_t aspx_hcb_noise_level_dt_bits[59] = {
++    16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
++    16, 16, 16, 16, 16, 14, 16, 13, 11,  8,  6,  4,  3,  1,  2,  5,
++     7, 10, 10, 12, 13, 13, 14, 15, 14, 15, 15, 16, 16, 16, 16, 16,
++    16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
++};
++
++static const uint16_t aspx_hcb_noise_level_dt_codes[59] = {
++    0x00ff70, 0x00ff71, 0x00ff72, 0x00ff73, 0x00ff74, 0x00ff75, 0x00ff76,
++    0x00ff77, 0x00ff78, 0x00ff79, 0x00ff7a, 0x00ff7b, 0x00ff7c, 0x00ff7d,
++    0x00ff7e, 0x00ff7f, 0x00ffe0, 0x00ffe1, 0x00ffe2, 0x00ffe3, 0x00ffe6,
++    0x003fd6, 0x00ffe7, 0x001ffe, 0x0007fe, 0x0000fe, 0x00003e, 0x00000e,
++    0x000006, 0x000000, 0x000002, 0x00001e, 0x00007e, 0x0003fe, 0x0003fc,
++    0x000ff6, 0x001fe8, 0x001fea, 0x003fd2, 0x007fae, 0x003fd3, 0x007ff2,
++    0x007faf, 0x00ffe8, 0x00ffe9, 0x00ffea, 0x00ffeb, 0x00ffec, 0x00ffed,
++    0x00ffee, 0x00ffef, 0x00fff8, 0x00fff9, 0x00fffa, 0x00fffb, 0x00fffc,
++    0x00fffd, 0x00fffe, 0x00ffff,
++};
++
++static const uint8_t aspx_hcb_noise_balance_f0_bits[13] = {
++    10, 10,  9,  7,  5,  3,  2,  1,  4,  6,  9, 10, 10,
++};
++
++static const uint16_t aspx_hcb_noise_balance_f0_codes[13] = {
++    0x0003fa, 0x0003fe, 0x0001fc, 0x00007e, 0x00001e, 0x000006,
++    0x000002, 0x000000, 0x00000e, 0x00003e, 0x0001fe, 0x0003ff,
++    0x0003fb,
++};
++
++static const uint8_t aspx_hcb_noise_balance_df_bits[25] = {
++    13, 13, 13, 13, 13, 12, 13, 10,  9,  7,  4,  2,  1,  3,  5,  6,
++     9, 11, 13, 13, 12, 12, 12, 12, 12,
++};
++
++static const uint16_t aspx_hcb_noise_balance_df_codes[25] = {
++    0x001fd8, 0x001fd9, 0x001fda, 0x001fdb, 0x001fdc, 0x000fea, 0x001fdd,
++    0x0003f8, 0x0001fe, 0x00007e, 0x00000e, 0x000002, 0x000000, 0x000006,
++    0x00001e, 0x00003e, 0x0001ff, 0x0007f4, 0x001fde, 0x001fdf, 0x000fe4,
++    0x000fe5, 0x000fe6, 0x000fe7, 0x000feb,
++};
++
++static const uint8_t aspx_hcb_noise_balance_dt_bits[25] = {
++    11, 11, 11, 11, 11, 11, 11, 10, 10,  6,  4,  3,  1,  2,  5,  8,
++     9, 11, 10, 11, 11, 11, 11, 11, 11,
++};
++
++static const uint16_t aspx_hcb_noise_balance_dt_codes[25] = {
++    0x0007e6, 0x0007e7, 0x0007e8, 0x0007e9, 0x0007ea, 0x0007eb, 0x0007ec,
++    0x0003fe, 0x0003ff, 0x00003e, 0x00000e, 0x000006, 0x000000, 0x000002,
++    0x00001e, 0x0000fe, 0x0001f8, 0x0007ed, 0x0003f2, 0x0007ee, 0x0007ef,
++    0x0007f8, 0x0007f9, 0x0007fa, 0x0007fb,
++};
++
++static const uint8_t aspx_codebook_signal_off[2][2] = { { 70, 35 }, { 24, 12 } };
++
++static const uint8_t acpl_codebook_signal_off[4][2][3] = {
++    {
++        { 0, 16, 16 },
++        { 0, 32, 32 },
++    }, {
++        { 0, 4, 4 },
++        { 0, 8, 8 },
++    }, {
++        { 0,  8,  8 },
++        { 0, 16, 16 },
++    }, {
++        { 10, 20, 20 },
++        { 20, 40, 40 },
++    },
++};
++
++static const uint8_t aspx_codebook_noise_off[2] = { 29, 12 };
++
++static const uint8_t scale_factors_bits[121] = {
++    17, 14, 14, 14, 14, 14, 14, 15, 14, 14, 14, 14, 14, 14, 14, 14,
++    13, 13, 14, 14, 14, 14, 14, 13, 14, 13, 13, 14, 14, 13, 14, 13,
++    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 12, 12, 12, 12, 11,
++    11, 11, 10,  9,  9,  8,  8,  6,  6,  4,  4,  3,  1,  4,  4,  5,
++     6,  7,  8,  8,  9,  9, 10, 10, 11, 11, 11, 11, 12, 11, 12, 12,
++    12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14,
++    14, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
++    14, 14, 14, 14, 14, 16, 14, 14, 17,
++};
++
++static const uint8_t scale_factors_codes[121] = {
++    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x01,
++    0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
++    0x19, 0x1a, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x1b,
++    0x14, 0x1c, 0x1d, 0x15, 0x16, 0x1e, 0x17, 0x1f,
++    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
++    0x28, 0x29, 0x2a, 0x1b, 0x1c, 0x1d, 0x1e, 0x12,
++    0x13, 0x14, 0x0d, 0x08, 0x09, 0x06, 0x07, 0x03,
++    0x04, 0x02, 0x03, 0x03, 0x01, 0x04, 0x05, 0x03,
++    0x05, 0x05, 0x08, 0x09, 0x0a, 0x0b, 0x0e, 0x0f,
++    0x15, 0x16, 0x17, 0x18, 0x1f, 0x19, 0x20, 0x21,
++    0x22, 0x23, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
++    0x31, 0x32, 0x33, 0x34, 0x18, 0x19, 0x1a, 0x1b,
++    0x1c, 0x35, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22,
++    0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a,
++    0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x01, 0x30, 0x31,
++    0x01,
++};
++
++static const uint16_t frame_len_base_48khz[] = {
++    1920, 1920, 2048, 1536, 1536, 960, 960, 1024,
++    768, 768, 512, 384, 384, 2048, 0, 0,
++};
++
++static const uint8_t frame_len_base_idx_48khz[] = {
++    1, 1, 0, 2, 2, 4, 4, 3, 5, 5, 6, 7, 7, 0, 0, 0,
++};
++
++static const uint16_t transf_length_48khz_2048[] = {
++    128, 256, 512, 1024, 2048,
++};
++
++static const uint16_t transf_length_48khz_1920[] = {
++    120, 240, 480, 960, 1920,
++};
++
++static const uint16_t transf_length_48khz_1536[] = {
++    96, 192, 384, 768, 1536,
++};
++
++static const uint16_t transf_length_48khz_1024[] = {
++    128, 256, 512, 1024, 1024,
++};
++
++static const uint16_t transf_length_48khz_960[] = {
++    120, 240, 480, 960, 960,
++};
++
++static const uint16_t transf_length_48khz_768[] = {
++    96, 192, 384, 768, 768,
++};
++
++static const uint16_t transf_length_48khz_512[] = {
++    128, 256, 512, 512, 512,
++};
++
++static const uint16_t transf_length_48khz_384[] = {
++    96, 192, 384, 384, 384,
++};
++
++static const uint16_t *transf_length_48khz[8] = {
++    transf_length_48khz_2048,
++    transf_length_48khz_1920,
++    transf_length_48khz_1536,
++    transf_length_48khz_1024,
++    transf_length_48khz_960,
++    transf_length_48khz_768,
++    transf_length_48khz_512,
++    transf_length_48khz_384,
++};
++
++static const float kbd_window_alpha[8][5] = {
++    { 6.f, 5.f, 4.5f, 4.f, 3.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 3.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 3.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 4.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 4.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 4.0f },
++    { 6.f, 5.f, 4.5f, 0.f, 4.5f },
++    { 6.f, 5.f, 4.5f, 0.f, 4.5f },
++};
++
++static const uint8_t n_grp_bits_a[4][4] = {
++    { 15, 10, 8, 7 },
++    { 10,  7, 4, 3 },
++    {  8,  4, 3, 1 },
++    {  7,  3, 1, 1 },
++};
++
++static const uint8_t n_grp_bits_b[4] = {
++    7, 3, 1, 0,
++};
++
++static const uint8_t n_grp_bits_c[4] = {
++    3, 1, 0, 0,
++};
++
++static const uint8_t channel_mode_bits[] = {
++    1, 2, 4, 4, 4, 7, 7, 7, 7, 7, 7, 8, 8, 9, 9, 9, 9,
++};
++
++static const uint16_t channel_mode_codes[] = {
++    0, 2, 12, 13, 14, 120, 121, 122, 123, 124, 125, 252, 253, 508, 509, 510, 511,
++};
++
++static const uint8_t bitrate_indicator_bits[] = {
++    3, 3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
++};
++
++static const uint8_t bitrate_indicator_codes[] = {
++    0, 2, 4, 6, 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31,
++};
++
++static const uint8_t asf_codebook_dim[] = {
++    4, 4, 4, 4, 2, 2, 2, 2, 2, 2, 2,
++};
++
++static const uint8_t asf_codebook_unsigned[] = {
++    0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1,
++};
++
++static const uint8_t asf_codebook_off[] = {
++    1, 1, 0, 0, 4, 4, 0, 0, 0, 0, 0,
++};
++
++static const uint8_t asf_codebook_mod[] = {
++    3, 3, 3, 3, 9, 9, 8, 8, 13, 13, 17,
++};
++
++static const uint8_t asf_codebook_1_bits[81] = {
++     9,  9, 12, 10,  7, 10, 12, 10, 11, 10,  7, 10,  7,  5,  7,  9,
++     7, 10, 11,  8,  9,  9,  7,  9, 11, 10, 12,  9,  7, 10,  7,  5,
++     7,  9,  7, 10,  7,  5,  7,  5,  1,  5,  7,  5,  7, 10,  7,  8,
++     7,  5,  7, 10,  7,  9, 12, 10, 11,  9,  7, 10,  9,  8, 12, 10,
++     7,  9,  7,  5,  7,  9,  7, 10, 12, 10, 12, 10,  7, 10, 12,  9,
++     9,
++};
++
++static const uint8_t asf_codebook_1_codes[81] = {
++    0x0b, 0x0c, 0x00, 0x04, 0x08, 0x05, 0x01, 0x06, 0x04, 0x07, 0x09, 0x08, 0x0a, 0x08, 0x0b, 0x0d,
++    0x0c, 0x09, 0x05, 0x0d, 0x0e, 0x0f, 0x0d, 0x10, 0x06, 0x0a, 0x02, 0x11, 0x0e, 0x0b, 0x0f, 0x09,
++    0x10, 0x12, 0x11, 0x0c, 0x12, 0x0a, 0x13, 0x0b, 0x01, 0x0c, 0x14, 0x0d, 0x15, 0x0d, 0x16, 0x0e,
++    0x17, 0x0e, 0x18, 0x0e, 0x19, 0x13, 0x03, 0x0f, 0x07, 0x14, 0x1a, 0x10, 0x15, 0x0f, 0x04, 0x11,
++    0x1b, 0x16, 0x1c, 0x0f, 0x1d, 0x17, 0x1e, 0x12, 0x05, 0x13, 0x06, 0x14, 0x1f, 0x15, 0x07, 0x18,
++    0x19,
++};
++
++static const uint8_t asf_codebook_2_bits[81] = {
++     8,  7,  9,  8,  6,  8,  9,  8,  9,  8,  6,  7,  6,  5,  6,  7,
++     6,  8,  9,  7,  7,  7,  6,  7,  9,  8,  9,  8,  6,  8,  6,  5,
++     6,  7,  6,  8,  6,  5,  6,  5,  3,  5,  6,  5,  6,  8,  6,  7,
++     6,  5,  6,  8,  6,  8,  9,  8,  9,  8,  6,  7,  7,  7,  9,  8,
++     6,  7,  6,  4,  6,  8,  6,  8,  9,  8,  9,  8,  6,  8,  9,  7,
++     8,
++};
++
++static const uint8_t asf_codebook_2_codes[81] = {
++    0x06, 0x0e, 0x00, 0x07, 0x0e, 0x08, 0x01, 0x09, 0x02, 0x0a, 0x0f, 0x0f, 0x10, 0x13, 0x11, 0x10,
++    0x12, 0x0b, 0x03, 0x11, 0x12, 0x13, 0x13, 0x14, 0x04, 0x0c, 0x05, 0x0d, 0x14, 0x0e, 0x15, 0x14,
++    0x16, 0x15, 0x17, 0x0f, 0x18, 0x15, 0x19, 0x16, 0x07, 0x17, 0x1a, 0x18, 0x1b, 0x10, 0x1c, 0x16,
++    0x1d, 0x19, 0x1e, 0x11, 0x1f, 0x12, 0x06, 0x13, 0x07, 0x14, 0x20, 0x17, 0x18, 0x19, 0x08, 0x15,
++    0x21, 0x1a, 0x22, 0x0d, 0x23, 0x16, 0x24, 0x17, 0x09, 0x18, 0x0a, 0x19, 0x25, 0x1a, 0x0b, 0x1b,
++    0x1b,
++};
++
++static const uint8_t asf_codebook_3_bits[81] = {
++     1,  4,  9,  4,  5,  9, 10, 10, 12,  4,  6, 10,  5,  6,  9, 10,
++     9, 11, 10, 11, 14, 10, 10, 12, 12, 11, 13,  4,  6, 11,  6,  7,
++    10, 11, 10, 12,  5,  7, 11,  6,  6, 10, 10,  9, 11,  9, 10, 13,
++     9,  9, 12, 11, 11, 12,  9, 10, 15, 10, 11, 15, 14, 13, 15,  9,
++    10, 14,  9, 10, 13, 13, 12, 14, 11, 12, 15, 11, 11, 14, 13, 12,
++    14,
++};
++
++static const uint8_t asf_codebook_3_codes[81] = {
++    0x01, 0x04, 0x0d, 0x05, 0x05, 0x0e, 0x0a, 0x0b, 0x05, 0x06, 0x04, 0x0c, 0x06, 0x05, 0x0f, 0x0d,
++    0x10, 0x07, 0x0e, 0x08, 0x02, 0x0f, 0x10, 0x06, 0x07, 0x09, 0x04, 0x07, 0x06, 0x0a, 0x07, 0x06,
++    0x11, 0x0b, 0x12, 0x08, 0x07, 0x07, 0x0c, 0x08, 0x09, 0x13, 0x14, 0x11, 0x0d, 0x12, 0x15, 0x05,
++    0x13, 0x14, 0x09, 0x0e, 0x0f, 0x0a, 0x15, 0x16, 0x00, 0x17, 0x10, 0x01, 0x03, 0x06, 0x02, 0x16,
++    0x18, 0x04, 0x17, 0x19, 0x07, 0x08, 0x0b, 0x05, 0x11, 0x0c, 0x03, 0x12, 0x13, 0x06, 0x09, 0x0d,
++    0x07,
++};
++
++static const uint8_t asf_codebook_4_bits[81] = {
++     4,  4,  9,  5,  4,  8,  9,  8, 11,  4,  5,  8,  5,  4,  8,  8,
++     8, 10,  9,  9, 11,  8,  8, 10, 11, 10, 12,  4,  5,  8,  5,  4,
++     8,  9,  8, 10,  4,  4,  8,  4,  4,  7,  8,  7,  9,  8,  8, 11,
++     8,  7, 10, 10,  9, 10,  9,  8, 11,  8,  8, 11, 11, 10, 12,  8,
++     8, 11,  8,  7, 10, 10,  9, 11, 11, 10, 12, 10,  9, 11, 12, 10,
++    11,
++};
++
++static const uint8_t asf_codebook_4_codes[81] = {
++    0x05, 0x06, 0x0a, 0x05, 0x07, 0x0a, 0x0b, 0x0b, 0x02, 0x08, 0x06, 0x0c, 0x07, 0x09, 0x0d, 0x0e,
++    0x0f, 0x07, 0x0c, 0x0d, 0x03, 0x10, 0x11, 0x08, 0x04, 0x09, 0x00, 0x0a, 0x08, 0x12, 0x09, 0x0b,
++    0x13, 0x0e, 0x14, 0x0a, 0x0c, 0x0d, 0x15, 0x0e, 0x0f, 0x10, 0x16, 0x11, 0x0f, 0x17, 0x18, 0x05,
++    0x19, 0x12, 0x0b, 0x0c, 0x10, 0x0d, 0x11, 0x1a, 0x06, 0x1b, 0x1c, 0x07, 0x08, 0x0e, 0x01, 0x1d,
++    0x1e, 0x09, 0x1f, 0x13, 0x0f, 0x10, 0x12, 0x0a, 0x0b, 0x11, 0x02, 0x12, 0x13, 0x0c, 0x03, 0x13,
++    0x0d,
++};
++
++static const uint8_t asf_codebook_5_bits[81] = {
++    14, 13, 12, 12, 11, 11, 12, 13, 14, 13, 12, 10,  9,  9,  9, 10,
++    11, 13, 13, 10,  9,  8,  7,  7,  9, 10, 12, 12,  9,  8,  5,  4,
++     5,  7,  9, 12, 12,  9,  7,  4,  1,  4,  7,  9, 12, 11,  9,  7,
++     5,  4,  5,  8,  9, 12, 12, 10,  9,  7,  7,  8,  9, 10, 12, 13,
++    11, 10,  9,  9, 10, 10, 12, 13, 14, 12, 12, 12, 11, 11, 12, 13,
++    14,
++};
++
++static const uint8_t asf_codebook_5_codes[81] = {
++    0x00, 0x02, 0x05, 0x06, 0x0b, 0x0c, 0x07, 0x03, 0x01, 0x04, 0x08, 0x09, 0x09, 0x0a, 0x0b, 0x0a,
++    0x0d, 0x05, 0x06, 0x0b, 0x0c, 0x0c, 0x08, 0x09, 0x0d, 0x0c, 0x09, 0x0a, 0x0e, 0x0d, 0x04, 0x04,
++    0x05, 0x0a, 0x0f, 0x0b, 0x0c, 0x10, 0x0b, 0x05, 0x01, 0x06, 0x0c, 0x11, 0x0d, 0x0e, 0x12, 0x0d,
++    0x06, 0x07, 0x07, 0x0e, 0x13, 0x0e, 0x0f, 0x0d, 0x14, 0x0e, 0x0f, 0x0f, 0x15, 0x0e, 0x10, 0x07,
++    0x0f, 0x0f, 0x16, 0x17, 0x10, 0x11, 0x11, 0x08, 0x02, 0x12, 0x13, 0x14, 0x10, 0x11, 0x15, 0x09,
++    0x03,
++};
++
++static const uint8_t asf_codebook_6_bits[81] = {
++    12, 11, 10, 10, 10, 10, 10, 11, 12, 11,  9,  8,  8,  8,  8,  8,
++     9, 11, 10,  8,  6,  6,  6,  5,  6,  8, 10, 10,  8,  6,  4,  4,
++     4,  5,  8, 10, 10,  8,  6,  4,  4,  4,  6,  8, 10, 10,  8,  5,
++     4,  4,  4,  6,  8, 10, 10,  8,  6,  5,  6,  5,  6,  8, 11, 11,
++     9,  8,  8,  8,  8,  8,  9, 11, 12, 11, 10, 10, 11, 10, 10, 11,
++    12,
++};
++
++static const uint8_t asf_codebook_6_codes[81] = {
++    0x00, 0x02, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x03, 0x01, 0x04, 0x0c, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
++    0x0d, 0x05, 0x0b, 0x0d, 0x07, 0x08, 0x09, 0x09, 0x0a, 0x0e, 0x0c, 0x0d, 0x0f, 0x0b, 0x07, 0x08,
++    0x09, 0x0a, 0x10, 0x0e, 0x0f, 0x11, 0x0c, 0x0a, 0x0b, 0x0c, 0x0d, 0x12, 0x10, 0x11, 0x13, 0x0b,
++    0x0d, 0x0e, 0x0f, 0x0e, 0x14, 0x12, 0x13, 0x15, 0x0f, 0x0c, 0x10, 0x0d, 0x11, 0x16, 0x06, 0x07,
++    0x0e, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x0f, 0x08, 0x02, 0x09, 0x14, 0x15, 0x0a, 0x16, 0x17, 0x0b,
++    0x03,
++};
++
++static const uint8_t asf_codebook_7_bits[64] = {
++     1,  3,  6,  8,  9,  9, 10, 11,  3,  4,  6,  7,  8,  8,  9, 10,
++     6,  5,  7,  8,  8,  9, 10, 11,  8,  7,  8,  8,  9,  9, 10, 11,
++     9,  8,  8,  9, 10, 10, 10, 11,  9,  8,  9,  9, 10, 10, 11, 12,
++    10,  9, 10, 10, 10, 11, 12, 12, 12, 10, 11, 11, 12, 12, 12, 12,
++};
++
++static const uint8_t asf_codebook_7_codes[64] = {
++    0x01, 0x02, 0x07, 0x0b, 0x0a, 0x0b, 0x06, 0x04, 0x03, 0x03, 0x08, 0x0b, 0x0c, 0x0d, 0x0c, 0x07,
++    0x09, 0x05, 0x0c, 0x0e, 0x0f, 0x0d, 0x08, 0x05, 0x10, 0x0d, 0x11, 0x12, 0x0e, 0x0f, 0x09, 0x06,
++    0x10, 0x13, 0x14, 0x11, 0x0a, 0x0b, 0x0c, 0x07, 0x12, 0x15, 0x13, 0x14, 0x0d, 0x0e, 0x08, 0x00,
++    0x0f, 0x15, 0x10, 0x11, 0x12, 0x09, 0x01, 0x02, 0x03, 0x13, 0x0a, 0x0b, 0x04, 0x05, 0x06, 0x07,
++};
++
++static const uint8_t asf_codebook_8_bits[64] = {
++     4,  4,  5,  6,  7,  8,  9, 10,  4,  3,  4,  5,  6,  7,  8,  9,
++     5,  4,  4,  5,  6,  7,  8,  9,  6,  5,  5,  5,  6,  7,  8,  9,
++     7,  6,  6,  6,  7,  7,  9, 10,  8,  7,  7,  7,  7,  8,  9, 10,
++     9,  8,  8,  8,  8,  9,  9, 10, 11,  9,  9,  9, 10, 10, 10, 11,
++};
++
++static const uint8_t asf_codebook_8_codes[64] = {
++    0x08, 0x09, 0x09, 0x0a, 0x09, 0x08, 0x04, 0x01, 0x0a, 0x07, 0x0b, 0x0a, 0x0b, 0x0a, 0x09, 0x05,
++    0x0b, 0x0c, 0x0d, 0x0c, 0x0c, 0x0b, 0x0a, 0x06, 0x0d, 0x0d, 0x0e, 0x0f, 0x0e, 0x0c, 0x0b, 0x07,
++    0x0d, 0x0f, 0x10, 0x11, 0x0e, 0x0f, 0x08, 0x02, 0x0c, 0x10, 0x11, 0x12, 0x13, 0x0d, 0x09, 0x03,
++    0x0a, 0x0e, 0x0f, 0x10, 0x11, 0x0b, 0x0c, 0x04, 0x00, 0x0d, 0x0e, 0x0f, 0x05, 0x06, 0x07, 0x01,
++};
++
++static const uint8_t asf_codebook_9_bits[169] = {
++     1,  3,  6,  8,  9, 10, 10, 11, 11, 12, 12, 12, 13,  3,  4,  6,
++     7,  8,  9,  9, 10, 10, 11, 11, 11, 12,  6,  6,  7,  8,  9,  9,
++    10, 10, 10, 11, 11, 12, 12,  8,  7,  8,  9,  9, 10, 10, 11, 11,
++    11, 12, 12, 12,  9,  8,  9,  9, 10, 10, 11, 11, 11, 12, 12, 12,
++    13, 10,  9,  9, 10, 10, 10, 11, 11, 11, 12, 12, 12, 13, 10,  9,
++    10, 10, 11, 11, 11, 12, 12, 12, 12, 13, 13, 11, 10, 10, 11, 11,
++    12, 12, 12, 12, 12, 13, 13, 13, 11, 10, 10, 11, 11, 11, 12, 12,
++    12, 13, 13, 13, 14, 12, 11, 11, 11, 11, 12, 12, 12, 13, 13, 13,
++    14, 14, 12, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 12,
++    11, 11, 12, 12, 12, 13, 13, 13, 13, 13, 14, 14, 13, 12, 12, 12,
++    13, 13, 13, 13, 14, 14, 14, 14, 14,
++};
++
++static const uint8_t asf_codebook_9_codes[169] = {
++    0x01, 0x02, 0x08, 0x14, 0x1b, 0x20, 0x21, 0x1e, 0x1f, 0x11, 0x12, 0x13, 0x06, 0x03, 0x03, 0x09,
++    0x0d, 0x15, 0x1c, 0x1d, 0x22, 0x23, 0x20, 0x21, 0x22, 0x14, 0x0a, 0x0b, 0x0e, 0x16, 0x1e, 0x1f,
++    0x24, 0x25, 0x26, 0x23, 0x24, 0x15, 0x16, 0x17, 0x0f, 0x18, 0x20, 0x21, 0x27, 0x28, 0x25, 0x26,
++    0x27, 0x17, 0x18, 0x19, 0x22, 0x19, 0x23, 0x24, 0x29, 0x2a, 0x28, 0x29, 0x2a, 0x1a, 0x1b, 0x1c,
++    0x07, 0x2b, 0x25, 0x26, 0x2c, 0x2d, 0x2e, 0x2b, 0x2c, 0x2d, 0x1d, 0x1e, 0x1f, 0x08, 0x2f, 0x27,
++    0x30, 0x31, 0x2e, 0x2f, 0x30, 0x20, 0x21, 0x22, 0x23, 0x09, 0x0a, 0x31, 0x32, 0x33, 0x32, 0x33,
++    0x24, 0x25, 0x26, 0x27, 0x28, 0x0b, 0x0c, 0x0d, 0x34, 0x34, 0x35, 0x35, 0x36, 0x37, 0x29, 0x2a,
++    0x2b, 0x0e, 0x0f, 0x10, 0x00, 0x2c, 0x38, 0x39, 0x3a, 0x3b, 0x2d, 0x2e, 0x2f, 0x11, 0x12, 0x13,
++    0x01, 0x02, 0x30, 0x3c, 0x3d, 0x31, 0x32, 0x33, 0x34, 0x14, 0x15, 0x16, 0x17, 0x03, 0x04, 0x35,
++    0x3e, 0x3f, 0x36, 0x37, 0x38, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x05, 0x06, 0x1d, 0x39, 0x3a, 0x3b,
++    0x1e, 0x1f, 0x20, 0x21, 0x07, 0x08, 0x09, 0x0a, 0x0b,
++};
++
++static const uint8_t asf_codebook_10_bits[169] = {
++     6,  5,  6,  6,  7,  8,  9, 10, 10, 11, 11, 12, 12,  5,  4,  4,
++     5,  6,  7,  7,  8,  9, 10, 10, 10, 11,  6,  4,  4,  5,  6,  6,
++     7,  8,  9,  9, 10, 10, 11,  6,  5,  5,  5,  6,  7,  7,  8,  8,
++     9, 10, 10, 11,  7,  6,  6,  6,  6,  7,  7,  8,  9,  9, 10, 10,
++    11,  8,  7,  6,  7,  7,  7,  8,  8,  9,  9, 10, 10, 11,  9,  7,
++     7,  7,  7,  8,  8,  9,  9, 10, 10, 10, 12, 10,  8,  8,  8,  8,
++     8,  9,  9,  9, 10, 10, 11, 12, 10,  8,  8,  8,  8,  9,  9,  9,
++    10, 10, 10, 11, 12, 11,  9,  9,  9,  9,  9, 10, 10, 10, 10, 11,
++    11, 13, 11, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 13, 12,
++    10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 12, 12, 12, 11, 11, 11,
++    11, 11, 11, 11, 12, 12, 13, 12, 13,
++};
++
++static const uint8_t asf_codebook_10_codes[169] = {
++    0x14, 0x11, 0x15, 0x16, 0x17, 0x1a, 0x1d, 0x11, 0x12, 0x07, 0x08, 0x02, 0x03, 0x12, 0x0c, 0x0d,
++    0x13, 0x17, 0x18, 0x19, 0x1b, 0x1e, 0x13, 0x14, 0x15, 0x09, 0x18, 0x0e, 0x0f, 0x14, 0x19, 0x1a,
++    0x1a, 0x1c, 0x1f, 0x20, 0x16, 0x17, 0x0a, 0x1b, 0x15, 0x16, 0x17, 0x1c, 0x1b, 0x1c, 0x1d, 0x1e,
++    0x21, 0x18, 0x19, 0x0b, 0x1d, 0x1d, 0x1e, 0x1f, 0x20, 0x1e, 0x1f, 0x1f, 0x22, 0x23, 0x1a, 0x1b,
++    0x0c, 0x20, 0x20, 0x21, 0x21, 0x22, 0x23, 0x21, 0x22, 0x24, 0x25, 0x1c, 0x1d, 0x0d, 0x26, 0x24,
++    0x25, 0x26, 0x27, 0x23, 0x24, 0x27, 0x28, 0x1e, 0x1f, 0x20, 0x04, 0x21, 0x25, 0x26, 0x27, 0x28,
++    0x29, 0x29, 0x2a, 0x2b, 0x22, 0x23, 0x0e, 0x05, 0x24, 0x2a, 0x2b, 0x2c, 0x2d, 0x2c, 0x2d, 0x2e,
++    0x25, 0x26, 0x27, 0x0f, 0x06, 0x10, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x28, 0x29, 0x2a, 0x2b, 0x11,
++    0x12, 0x00, 0x13, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x14, 0x15, 0x16, 0x17, 0x01, 0x07,
++    0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x18, 0x19, 0x1a, 0x08, 0x09, 0x0a, 0x1b, 0x1c, 0x1d,
++    0x1e, 0x1f, 0x20, 0x21, 0x0b, 0x0c, 0x02, 0x0d, 0x03,
++};
++
++static const uint8_t asf_codebook_11_bits[289] = {
++     3,  4,  6,  7,  8,  9,  9, 10, 10, 11, 11, 11, 12, 12, 12, 12,
++    10,  4,  4,  5,  6,  7,  8,  8,  9,  9,  9,  9, 10, 10, 10, 11,
++    11,  9,  6,  5,  6,  6,  7,  7,  8,  8,  9,  9,  9,  9, 10, 10,
++    10, 11,  8,  7,  6,  6,  7,  7,  7,  8,  8,  9,  9,  9,  9, 10,
++    10, 10, 11,  8,  8,  7,  7,  7,  7,  8,  8,  9,  9,  9,  9, 10,
++    10, 10, 10, 11,  8,  9,  7,  7,  7,  8,  8,  8,  9,  9,  9, 10,
++    10, 10, 10, 11, 11,  8,  9,  8,  8,  8,  8,  8,  9,  9,  9, 10,
++    10, 10, 10, 10, 11, 11,  8, 10,  9,  8,  8,  8,  9,  9,  9,  9,
++    10, 10, 10, 11, 11, 11, 11,  9, 10,  9,  9,  9,  9,  9,  9,  9,
++    10, 10, 10, 10, 11, 11, 11, 11,  9, 11,  9,  9,  9,  9,  9, 10,
++    10, 10, 10, 10, 10, 11, 11, 11, 12,  9, 11,  9,  9,  9,  9, 10,
++    10, 10, 10, 10, 10, 11, 11, 11, 11, 12,  9, 11, 10,  9,  9,  9,
++    10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12,  9, 12, 10, 10, 10,
++    10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 12, 12,  9, 11, 10, 10,
++    10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12,  9, 12, 11,
++    10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12,  9, 12,
++    11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12,  9,
++    10,  8,  8,  8,  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9,
++     5,
++};
++
++static const uint8_t asf_codebook_11_codes[289] = {
++    0x07, 0x0b, 0x1f, 0x2f, 0x3d, 0x36, 0x37, 0x26, 0x27, 0x0d, 0x0e, 0x0f, 0x00, 0x01, 0x02, 0x03,
++    0x28, 0x0c, 0x0d, 0x13, 0x20, 0x30, 0x3e, 0x3f, 0x38, 0x39, 0x3a, 0x3b, 0x29, 0x2a, 0x2b, 0x10,
++    0x11, 0x3c, 0x21, 0x14, 0x22, 0x23, 0x31, 0x32, 0x40, 0x41, 0x3d, 0x3e, 0x3f, 0x40, 0x2c, 0x2d,
++    0x2e, 0x12, 0x42, 0x33, 0x24, 0x25, 0x34, 0x35, 0x36, 0x43, 0x44, 0x41, 0x42, 0x43, 0x44, 0x2f,
++    0x30, 0x31, 0x13, 0x45, 0x46, 0x37, 0x38, 0x39, 0x3a, 0x47, 0x48, 0x45, 0x46, 0x47, 0x48, 0x32,
++    0x33, 0x34, 0x35, 0x14, 0x49, 0x49, 0x3b, 0x3c, 0x3d, 0x4a, 0x4b, 0x4c, 0x4a, 0x4b, 0x4c, 0x36,
++    0x37, 0x38, 0x39, 0x15, 0x16, 0x4d, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x4e, 0x4f, 0x50, 0x3a,
++    0x3b, 0x3c, 0x3d, 0x3e, 0x17, 0x18, 0x53, 0x3f, 0x51, 0x54, 0x55, 0x56, 0x52, 0x53, 0x54, 0x55,
++    0x40, 0x41, 0x42, 0x19, 0x1a, 0x1b, 0x1c, 0x56, 0x43, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d,
++    0x44, 0x45, 0x46, 0x47, 0x1d, 0x1e, 0x1f, 0x20, 0x5e, 0x21, 0x5f, 0x60, 0x61, 0x62, 0x63, 0x48,
++    0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x22, 0x23, 0x24, 0x04, 0x64, 0x25, 0x65, 0x66, 0x67, 0x68, 0x4e,
++    0x4f, 0x50, 0x51, 0x52, 0x53, 0x26, 0x27, 0x28, 0x29, 0x05, 0x69, 0x2a, 0x54, 0x6a, 0x6b, 0x6c,
++    0x55, 0x56, 0x57, 0x58, 0x59, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x06, 0x6d, 0x07, 0x5a, 0x5b, 0x5c,
++    0x5d, 0x5e, 0x5f, 0x60, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x08, 0x09, 0x6e, 0x36, 0x61, 0x62,
++    0x63, 0x64, 0x65, 0x66, 0x67, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x0a, 0x0b, 0x0c, 0x6f, 0x0d, 0x3c,
++    0x68, 0x69, 0x6a, 0x3d, 0x3e, 0x3f, 0x40, 0x41, 0x42, 0x43, 0x0e, 0x0f, 0x10, 0x11, 0x70, 0x12,
++    0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x71,
++    0x6b, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
++    0x15,
++};
++
++static const uint16_t sfb_offset_48khz_2048[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40,
++    44, 52, 60, 68, 76, 84, 92, 100, 108, 116,
++    124, 136, 148, 160, 172, 188, 204, 220, 240,
++    260, 284, 308, 336, 364, 396, 432, 468, 508,
++    552, 600, 652, 704, 768, 832, 896, 960, 1024,
++    1088, 1152, 1216, 1280, 1344, 1408, 1472, 1536,
++    1600, 1664, 1728, 1792, 1856, 1920, 1984, 2048,
++    2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072,
++    3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096,
++    4224, 4352, 4480, 4608, 4736, 4864, 4992, 5120,
++    5248, 5376, 5504, 5632, 5760, 5888, 6016, 6144,
++    6272, 6400, 6528, 6656, 6784, 6912, 7040, 7168,
++    7296, 7424, 7552, 7680, 7808, 7936, 8064, 8192,
++};
++
++static const uint16_t sfb_offset_48khz_1920[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 52, 60, 68,
++    76, 84, 92, 100, 108, 116, 124, 136, 148, 160, 172, 188,
++    204, 220, 240, 260, 284, 308, 336, 364, 396, 432, 468,
++    508, 552, 600, 652, 704, 768, 832, 896, 960, 1024, 1088,
++    1152, 1216, 1280, 1344, 1408, 1472, 1536, 1600, 1664, 1728,
++    1792, 1856, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816,
++    2944, 3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096,
++    4224, 4352, 4480, 4608, 4736, 4864, 4992, 5120, 5248, 5376,
++    5504, 5632, 5760, 5888, 6016, 6144, 6272, 6400, 6528, 6656,
++    6784, 6912, 7040, 7168, 7296, 7424, 7552, 7680,
++};
++
++static const uint16_t sfb_offset_48khz_1536[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40,
++    44, 52, 60, 68, 76, 84, 92, 100, 108, 116,
++    124, 136, 148, 160, 172, 188, 204, 220, 240,
++    260, 284, 308, 336, 364, 396, 432, 468, 508,
++    552, 600, 652, 704, 768, 832, 896, 960, 1024,
++    1088, 1152, 1216, 1280, 1344, 1408, 1472, 1536,
++    1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560,
++    2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584,
++    3712, 3840, 3968, 4096, 4224, 4352, 4480, 4608,
++    4736, 4864, 4992, 5120, 5248, 5376, 5504, 5632,
++    5760, 5888, 6016, 6144,
++};
++
++static const uint16_t sfb_offset_48khz_1024[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48,
++    56, 64, 72, 80, 88, 96, 108, 120, 132, 144,
++    160, 176, 196, 216, 240, 264, 292, 320, 352,
++    384, 416, 448, 480, 512, 544, 576, 608, 640,
++    672, 704, 736, 768, 800, 832, 864, 896, 928,
++    1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920,
++    2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944,
++    3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968,
++    4096,
++};
++
++static const uint16_t sfb_offset_48khz_960[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72,
++    80, 88, 96, 108, 120, 132, 144, 160, 176, 196, 216, 240,
++    264, 292, 320, 352, 384, 416, 448, 480, 512, 544,
++    576, 608, 640, 672, 704, 736, 768, 800, 832, 864, 896,
++    928, 960, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920,
++    2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072,
++    3200, 3328, 3456, 3584, 3712, 3840,
++};
++
++static const uint16_t sfb_offset_48khz_768[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48,
++    56, 64, 72, 80, 88, 96, 108, 120, 132, 144,
++    160, 176, 196, 216, 240, 264, 292, 320, 352,
++    384, 416, 448, 480, 512, 544, 576, 608, 640,
++    672, 704, 736, 768, 896, 1024, 1152, 1280, 1408,
++    1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432,
++    2560, 2688, 2816, 2944, 3072,
++};
++
++static const uint16_t sfb_offset_48khz_512[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52,
++    56, 60, 68, 76, 84, 92, 100, 112, 124, 136, 148, 164,
++    184, 208, 236, 268, 300, 332, 364, 396, 428, 460, 512,
++    576, 640, 704, 768, 832, 896, 960, 1024, 1088, 1152,
++    1216, 1280, 1344, 1408, 1472, 1536, 1600, 1664, 1728,
++    1792, 1856, 1920, 1984, 2048,
++};
++
++static const uint16_t sfb_offset_48khz_480[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56,
++    60, 68, 76, 84, 92, 100, 112, 124, 136, 148, 164, 184,
++    208, 236, 268, 300, 332, 364, 396, 428, 460, 480, 512,
++    576, 640, 704, 768, 832, 896, 960, 1024, 1088, 1152,
++    1216, 1280, 1344, 1408, 1472, 1536, 1600, 1664, 1728,
++    1792, 1856, 1920,
++};
++
++static const uint16_t sfb_offset_48khz_384[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52,
++    56, 60, 68, 76, 84, 92, 100, 112, 124, 136, 148, 164,
++    184, 208, 236, 268, 300, 332, 364, 384, 448, 512, 576,
++    640, 704, 768, 832, 896, 960, 1024, 1088, 1152,
++    1216, 1280, 1344, 1408, 1472, 1536,
++};
++
++static const uint16_t sfb_offset_48khz_256[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 36, 44, 52, 64, 76,
++    92, 108, 128, 148, 172, 196, 224, 256, 288, 320,
++    352, 384, 416, 448, 480, 512, 576, 640, 704, 768,
++    832, 896, 960, 1024,
++};
++
++static const uint16_t sfb_offset_48khz_240[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 36, 44, 52, 64, 76, 92, 108,
++    128, 148, 172, 196, 224, 240, 256, 288, 320, 352, 384, 416,
++    448, 480, 512, 576, 640, 704, 768, 832, 896, 960,
++};
++
++static const uint16_t sfb_offset_48khz_192[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 36, 44, 52, 64, 76,
++    92, 108, 128, 148, 172, 192, 224, 256, 288, 320,
++    352, 384, 448, 512, 576, 640, 704, 768,
++};
++
++static const uint16_t sfb_offset_48khz_128[] = {
++    0, 4, 8, 12, 16, 20, 28, 36, 44, 56, 68, 80, 96, 112,
++    128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320,
++    352, 384, 416, 448, 480, 512,
++};
++
++static const uint16_t sfb_offset_48khz_120[] = {
++    0, 4, 8, 12, 16, 20, 28, 36, 44, 56, 68, 80, 96, 112,
++    120, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288,
++    320, 352, 384, 416, 448, 480,
++};
++
++static const uint16_t sfb_offset_48khz_96[] = {
++    0, 4, 8, 12, 16, 20, 28, 36, 44, 56, 68, 80, 96, 112,
++    128, 144, 160, 176, 192, 224, 256, 288, 320, 352, 384,
++};
++
++static const uint8_t snf_bits[22] = {
++    4, 7, 8, 8, 7, 6, 6, 6, 6, 5, 5, 4, 4, 3, 3, 3, 3, 4, 4, 6, 7, 6,
++};
++
++static const uint8_t snf_codes[22] = {
++    0x03, 0x01, 0x00, 0x01, 0x02, 0x02, 0x03, 0x04,
++    0x05, 0x04, 0x05, 0x04, 0x05, 0x04, 0x05, 0x06,
++    0x07, 0x06, 0x07, 0x06, 0x03, 0x07,
++};
++
++static const uint8_t aspx_int_class_bits[4] = {
++    1, 2, 3, 3,
++};
++
++static const uint8_t aspx_int_class_codes[4] = {
++    0, 2, 6, 7,
++};
++
++static const uint8_t sbg_template_lowres[] = {
++    10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
++    22, 24, 26, 28, 30, 32, 35, 38, 42, 46,
++};
++
++static const uint8_t sbg_template_highres[] = {
++    18, 19, 20, 21, 22, 23, 24, 26, 28, 30, 32, 34,
++    36, 38, 40, 42, 44, 47, 50, 53, 56, 59, 62,
++};
++
++static const uint8_t tab_border[5][3][5] = {
++    {
++        { 0, 6, 0, 0, 0, },
++        { 0, 3, 6, 0, 0, },
++        { 0, 2, 3, 4, 6, },
++    },
++    {
++        { 0, 8, 0, 0, 0, },
++        { 0, 4, 8, 0, 0, },
++        { 0, 2, 4, 6, 8, },
++    },
++    {
++        { 0,12, 0, 0, 0, },
++        { 0, 6,12, 0, 0, },
++        { 0, 3, 6, 9,12, },
++    },
++    {
++        { 0,15, 0, 0, 0, },
++        { 0, 8,15, 0, 0, },
++        { 0, 4, 8,12,15, },
++    },
++    {
++        { 0,16, 0, 0, 0, },
++        { 0, 8,16, 0, 0, },
++        { 0, 4, 8,12,16, },
++    },
++};
++
++static const uint8_t qmf_subbands[][4] = {
++    { 0, 0, 0, 0 },
++    { 1, 1, 1, 1 },
++    { 2, 2, 2, 2 },
++    { 3, 3, 3, 2 },
++    { 4, 4, 3, 3 },
++    { 5, 4, 4, 3 },
++    { 6, 5, 4, 3 },
++    { 7, 5, 5, 3 },
++    { 8, 6, 5, 4 },
++    { 9, 6, 6, 4 },
++    {10, 7, 6, 4 },
++    {11, 8, 7, 5 },
++    {12, 9, 7, 5 },
++    {13,10, 8, 6 },
++    {14,11, 8, 6 },
++};
++
++static const uint8_t acpl_num_param_bands[] = {
++    15, 12, 9, 7,
++};
++
++static const uint8_t acpl_hcb_alpha_coarse_f0_bits[17] = {
++    10, 10,  9,  8,  6,  6,  5,  2,  1,  3,  5,  7,  7,  8,  9, 10,
++    10,
++};
++
++static const uint16_t acpl_hcb_alpha_coarse_f0_codes[17] = {
++    0x0003be, 0x0003fe, 0x0001fe, 0x0000fe, 0x00003e, 0x00003a,
++    0x00001e, 0x000002, 0x000000, 0x000006, 0x00001c, 0x00007e,
++    0x000076, 0x0000ee, 0x0001de, 0x0003ff, 0x0003bf,
++};
++
++static const uint8_t acpl_hcb_alpha_fine_f0_bits[33] = {
++    10, 12, 11, 11, 10, 10,  9,  8,  7,  7,  8,  7,  6,  6,  4,  3,
++     1,  3,  4,  6,  6,  7,  8,  8,  9,  9, 10, 10, 10, 10, 11, 12,
++    10,
++};
++
++static const uint16_t acpl_hcb_alpha_fine_f0_codes[33] = {
++    0x0002ce, 0x000b5e, 0x0004fe, 0x0005ae, 0x00027e, 0x0002de,
++    0x00016a, 0x0000b2, 0x00004a, 0x00004b, 0x0000b6, 0x00004e,
++    0x000024, 0x00002e, 0x00000a, 0x000006, 0x000000, 0x000007,
++    0x000008, 0x00002f, 0x000026, 0x000058, 0x0000b4, 0x00009e,
++    0x00016e, 0x000166, 0x0002df, 0x0002cf, 0x00027c, 0x00027d,
++    0x0004ff, 0x000b5f, 0x0002d6,
++};
++
++static const uint8_t acpl_hcb_alpha_coarse_df_bits[33] = {
++    15, 18, 17, 17, 16, 15, 15, 13, 12, 11, 10,  9,  8,  7,  4,  3,
++     1,  2,  5,  7,  8,  9, 10, 11, 12, 13, 15, 16, 16, 17, 16, 18,
++    15,
++};
++
++static const uint32_t acpl_hcb_alpha_coarse_df_codes[33] = {
++    0x007c76, 0x03e3fe, 0x01f1f6, 0x01f1f7, 0x00f8ea, 0x007c74, 0x007c7c,
++    0x001f1c, 0x000f9e, 0x0007ce, 0x0003e2, 0x0001f0, 0x0000fa, 0x00007e,
++    0x00000e, 0x000006, 0x000000, 0x000002, 0x00001e, 0x00007f, 0x0000fb,
++    0x0001f2, 0x0003e6, 0x0007c6, 0x000f9f, 0x001f1e, 0x007c7e, 0x00f8fe,
++    0x00f8fa, 0x01f1fe, 0x00f8eb, 0x03e3ff, 0x007c77,
++};
++
++static const uint8_t acpl_hcb_alpha_fine_df_bits[65] = {
++    13, 17, 17, 17, 16, 17, 17, 17, 17, 16, 16, 16, 15, 15, 14, 13,
++    13, 12, 12, 11, 11, 11, 10, 10, 10,  9,  8,  7,  7,  5,  4,  3,
++     1,  3,  4,  5,  6,  7,  8,  9,  9, 10, 10, 11, 11, 12, 12, 12,
++    13, 13, 14, 15, 15, 16, 16, 17, 16, 16, 17, 16, 16, 17, 17, 17,
++    13,
++};
++
++static const uint32_t acpl_hcb_alpha_fine_df_codes[65] = {
++    0x0011de, 0x011ffe, 0x013dea, 0x013df6, 0x008eea, 0x013df7, 0x013dee,
++    0x013deb, 0x013dec, 0x008eee, 0x008ffe, 0x009efe, 0x0047fe, 0x004f7c,
++    0x0023fe, 0x0011fe, 0x0013fe, 0x0008f6, 0x0009ee, 0x000476, 0x00047a,
++    0x0004f6, 0x00023a, 0x00027a, 0x00027e, 0x00013e, 0x00009a, 0x00004c,
++    0x00004e, 0x000012, 0x00000a, 0x000006, 0x000000, 0x000007, 0x00000b,
++    0x000010, 0x000022, 0x000046, 0x00009b, 0x00013c, 0x00011c, 0x00023e,
++    0x00023c, 0x0004fe, 0x00047e, 0x0009fe, 0x0008fe, 0x0008f7, 0x0013ff,
++    0x0011df, 0x0027bc, 0x004f7e, 0x004776, 0x009efa, 0x009ef4, 0x013dfe,
++    0x008eeb, 0x008ee8, 0x013dff, 0x008ee9, 0x008eef, 0x011fff, 0x013ded,
++    0x013def, 0x0011dc,
++};
++
++static const uint8_t acpl_hcb_alpha_coarse_dt_bits[33] = {
++    14, 16, 15, 16, 15, 15, 14, 13, 12, 12, 10,  9,  8,  7,  5,  3,
++     1,  2,  4,  7,  8,  9, 10, 11, 12, 13, 14, 15, 15, 16, 15, 16,
++    14,
++};
++
++static const uint32_t acpl_hcb_alpha_coarse_dt_codes[33] = {
++    0x003efc, 0x00fbfa, 0x007ddc, 0x00fbfe, 0x007dde, 0x007dfc, 0x003ef6,
++    0x001f76, 0x000fba, 0x000fbe, 0x0003ec, 0x0001f2, 0x0000f8, 0x00007e,
++    0x00001e, 0x000006, 0x000000, 0x000002, 0x00000e, 0x00007f, 0x0000fa,
++    0x0001f3, 0x0003ed, 0x0007dc, 0x000fbc, 0x001f7a, 0x003ef7, 0x007dfe,
++    0x007ddf, 0x00fbff, 0x007ddd, 0x00fbfb, 0x003efd,
++};
++
++static const uint8_t acpl_hcb_alpha_fine_dt_bits[65] = {
++    16, 18, 18, 18, 17, 17, 17, 18, 17, 17, 17, 16, 16, 16, 15, 15,
++    14, 14, 13, 13, 13, 12, 11, 11, 10, 10,  9,  9,  7,  6,  5,  3,
++     1,  2,  5,  6,  7,  9,  9, 10, 10, 11, 11, 12, 12, 13, 13, 14,
++    14, 15, 15, 16, 16, 16, 17, 17, 17, 17, 17, 18, 17, 18, 18, 18,
++    16,
++};
++
++static const uint32_t acpl_hcb_alpha_fine_dt_codes[65] = {
++    0x00eeee, 0x03b3ee, 0x03b3f6, 0x03b3fc, 0x01d9bc, 0x01d9bd, 0x01d9b2,
++    0x03b3fe, 0x01d9be, 0x01d9f6, 0x01d9fc, 0x00ecda, 0x00ecfa, 0x00eeef,
++    0x00766e, 0x007776, 0x003b3a, 0x003bba, 0x001d9a, 0x001ddc, 0x001dde,
++    0x000eec, 0x000764, 0x000772, 0x0003b0, 0x0003b8, 0x0001da, 0x0001de,
++    0x000072, 0x000038, 0x00001e, 0x000006, 0x000000, 0x000002, 0x00001f,
++    0x00003a, 0x000073, 0x0001df, 0x0001db, 0x0003ba, 0x0003b1, 0x000773,
++    0x000765, 0x000eed, 0x000ecc, 0x001d9e, 0x001d9c, 0x003bbe, 0x003b3b,
++    0x00777e, 0x00767c, 0x00eefe, 0x00ecfc, 0x00ecd8, 0x01d9fd, 0x01d9fa,
++    0x01d9bf, 0x01d9b6, 0x01d9b3, 0x03b3fd, 0x01d9b7, 0x03b3ff, 0x03b3ef,
++    0x03b3f7, 0x00eeff,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_f0_bits[5] = {
++     1,  2,  3,  4,  4,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_f0_codes[5] = {
++    0x000000, 0x000002, 0x000006, 0x00000e, 0x00000f,
++};
++
++static const uint8_t acpl_hcb_beta_fine_f0_bits[9] = {
++     1,  2,  3,  4,  5,  6,  7,  8,  8,
++};
++
++static const uint8_t acpl_hcb_beta_fine_f0_codes[9] = {
++    0x000000, 0x000002, 0x000006, 0x00000e, 0x00001e, 0x00003e, 0x00007e, 0x0000fe, 0x0000ff,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_df_bits[9] = {
++     8,  6,  4,  3,  1,  2,  5,  7,  8,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_df_codes[9] = {
++    0x0000fe, 0x00003e, 0x00000e, 0x000006, 0x000000, 0x000002, 0x00001e, 0x00007e, 0x0000ff,
++};
++
++static const uint8_t acpl_hcb_beta_fine_df_bits[17] = {
++    13, 12, 10,  9,  8,  7,  5,  3,  1,  2,  4,  7,  8,  9,  9, 11,
++    13,
++};
++
++static const uint32_t acpl_hcb_beta_fine_df_codes[17] = {
++    0x001f1e, 0x000f8e, 0x0003e2, 0x0001f2, 0x0000fa, 0x00007e,
++    0x00001e, 0x000006, 0x000000, 0x000002, 0x00000e, 0x00007f,
++    0x0000fb, 0x0001f3, 0x0001f0, 0x0007c6, 0x001f1f,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_dt_bits[9] = {
++     8,  7,  5,  3,  1,  2,  4,  6,  8,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_dt_codes[9] = {
++    0x0000fe, 0x00007e, 0x00001e, 0x000006, 0x000000, 0x000002, 0x00000e, 0x00003e, 0x0000ff,
++};
++
++static const uint8_t acpl_hcb_beta_fine_dt_bits[17] = {
++    15, 14, 12, 10,  8,  7,  5,  3,  1,  2,  4,  7,  7,  9, 11, 13,
++    15,
++};
++
++static const uint32_t acpl_hcb_beta_fine_dt_codes[17] = {
++    0x007dfe, 0x003efe, 0x000fbe, 0x0003ee, 0x0000fa,
++    0x00007e, 0x00001e, 0x000006, 0x000000, 0x000002,
++    0x00000e, 0x00007f, 0x00007c, 0x0001f6, 0x0007de,
++    0x001f7e, 0x007dff,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_f0_bits[9] = {
++     5,  3,  3,  2,  2,  3,  4,  6,  6,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_f0_codes[9] = {
++    0x000001, 0x000006, 0x000007, 0x000001, 0x000002, 0x000001, 0x000001, 0x000001, 0x000000,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_f0_bits[17] = {
++     7,  5,  4,  4,  4,  3,  3,  3,  3,  3,  4,  5,  6,  6,  7,  7,
++     7,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_f0_codes[17] = {
++    0x00000d, 0x000002, 0x000000, 0x00000c, 0x00000e, 0x000001, 0x000003,
++    0x000005, 0x000004, 0x000002, 0x00000d, 0x00001f, 0x00003d, 0x000007,
++    0x000078, 0x00000c, 0x000079,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_df_bits[17] = {
++    13, 12, 12, 11,  9,  6,  4,  2,  1,  3,  5,  7,  9, 11, 12, 13,
++     9,
++};
++
++static const uint32_t acpl_hcb_beta3_coarse_df_codes[17] = {
++    0x000a93, 0x000548, 0x00054b, 0x0002a7, 0x0000ab, 0x000014,
++    0x000004, 0x000000, 0x000001, 0x000003, 0x00000b, 0x00002b,
++    0x0000aa, 0x0002a6, 0x00054a, 0x000a92, 0x0000a8,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_df_bits[33] = {
++    14, 15, 14, 13, 13, 12, 11, 11,  9,  8,  7,  6,  5,  4,  3,  2,
++     2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 12, 13, 14, 14, 14,
++    15,
++};
++
++static const uint32_t acpl_hcb_beta3_fine_df_codes[33] = {
++    0x0019e9, 0x0033f7, 0x0019f3, 0x000cf5, 0x000cfc, 0x00067d, 0x00033c,
++    0x0007ff, 0x0000ce, 0x000066, 0x000032, 0x000018, 0x00000d, 0x000007,
++    0x000002, 0x000000, 0x000002, 0x000006, 0x00000e, 0x00001e, 0x00003e,
++    0x00007e, 0x0000fe, 0x0001fe, 0x0003fe, 0x0007fe, 0x00067f, 0x00067b,
++    0x000cf8, 0x0019fa, 0x0019f2, 0x0019e8, 0x0033f6,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_dt_bits[17] = {
++    15, 15, 14, 12, 10,  7,  5,  3,  1,  2,  4,  6,  8, 11, 14, 14,
++     9,
++};
++
++static const uint16_t acpl_hcb_beta3_coarse_dt_codes[17] = {
++    0x000adc, 0x000add, 0x00056c, 0x00015a, 0x000057, 0x00000b, 0x000003,
++    0x000001, 0x000001, 0x000001, 0x000000, 0x000004, 0x000014, 0x0000ac,
++    0x00056f, 0x00056d, 0x00002a,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_dt_bits[33] = {
++    16, 16, 16, 16, 16, 16, 15, 14, 12, 11, 10,  9,  8,  7,  5,  3,
++     1,  2,  4,  7,  8,  9, 10, 11, 12, 13, 14, 15, 15, 16, 16, 16,
++    16,
++};
++
++static const uint32_t acpl_hcb_beta3_fine_dt_codes[33] = {
++    0x00501e, 0x00501d, 0x00501c, 0x00501b, 0x00510e, 0x00510d, 0x002809,
++    0x001442, 0x000500, 0x000281, 0x000141, 0x0000a1, 0x000052, 0x00002a,
++    0x00000b, 0x000003, 0x000001, 0x000000, 0x000004, 0x00002b, 0x000053,
++    0x0000a3, 0x000145, 0x000289, 0x000511, 0x000a20, 0x001405, 0x00280c,
++    0x002808, 0x00510f, 0x00510c, 0x00501f, 0x00501a,
++};
++
++static const uint8_t acpl_hcb_gamma_coarse_f0_bits[21] = {
++    13, 13, 13, 13, 11,  9,  7,  6,  5,  3,  2,  3,  3,  4,  3,  3,
++     8, 11, 12, 13, 13,
++};
++
++static const uint16_t acpl_hcb_gamma_coarse_f0_codes[21] = {
++    0x000af4, 0x000af8, 0x000af9, 0x000afb, 0x0002bc, 0x0000ae, 0x00002a, 0x000014,
++    0x00000b, 0x000001, 0x000003, 0x000005, 0x000000, 0x000004, 0x000004, 0x000003,
++    0x000056, 0x0002bf, 0x00057b, 0x000af5, 0x000afa,
++};
++
++static const uint8_t acpl_hcb_gamma_fine_f0_bits[41] = {
++    12, 13, 13, 12, 12, 12, 12, 11,  9, 10,  9,  8,  8,  7,  7,  6,
++     5,  5,  4,  4,  3,  3,  4,  4,  5,  5,  5,  5,  4,  3,  4,  7,
++     8,  9, 10, 11, 11, 12, 12, 12, 12,
++};
++
++static const uint32_t acpl_hcb_gamma_fine_f0_codes[41] = {
++    0x0004b6, 0x001c6d, 0x001c6c, 0x00049b, 0x0004b5, 0x0004b7, 0x000e35, 0x00024e,
++    0x0001c7, 0x00038c, 0x000097, 0x000048, 0x0000e2, 0x000070, 0x000073, 0x000013,
++    0x000008, 0x000017, 0x000005, 0x00000c, 0x000004, 0x000001, 0x00000d, 0x00000a,
++    0x00001f, 0x00001e, 0x000016, 0x00001d, 0x000006, 0x000000, 0x000007, 0x000072,
++    0x00004a, 0x000092, 0x00012c, 0x00024f, 0x00024c, 0x000e34, 0x0004b4, 0x00049a,
++    0x000e37,
++};
++
++static const uint8_t acpl_hcb_gamma_coarse_df_bits[41] = {
++    16, 16, 16, 16, 16, 16, 16, 16, 16, 15, 15, 14, 13, 13, 11, 10,
++     8,  7,  4,  2,  1,  3,  5,  7,  8, 10, 11, 13, 13, 14, 15, 16,
++    16, 16, 16, 16, 16, 16, 16, 16,  8,
++};
++
++static const uint32_t acpl_hcb_gamma_coarse_df_codes[41] = {
++    0x0053e1, 0x0053e0, 0x0053db, 0x0053da, 0x0053d9, 0x0053e2, 0x0053e4, 0x0053ea,
++    0x0053eb, 0x0029ea, 0x0029f4, 0x0014f4, 0x000a78, 0x000a7f, 0x000299, 0x00014d,
++    0x000051, 0x00002a, 0x000004, 0x000000, 0x000001, 0x000003, 0x00000b, 0x00002b,
++    0x000052, 0x00014e, 0x000298, 0x000a7e, 0x000a79, 0x0014f7, 0x0029f6, 0x0053ef,
++    0x0053ee, 0x0053e7, 0x0053e6, 0x0053e3, 0x0053e5, 0x0053d8, 0x0053d7, 0x0053d6,
++    0x000050,
++};
++
++static const uint8_t acpl_hcb_gamma_fine_df_bits[81] = {
++    17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
++    17, 17, 16, 16, 16, 15, 15, 15, 14, 14, 13, 13, 13, 12, 11, 11,
++    10,  9,  8,  7,  6,  5,  4,  3,  1,  3,  4,  5,  6,  7,  9,  9,
++    10, 11, 11, 12, 13, 13, 14, 14, 14, 15, 15, 15, 16, 16, 16, 17,
++    17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
++    17,
++};
++
++static const uint32_t acpl_hcb_gamma_fine_df_codes[81] = {
++    0x013e1f, 0x013e35, 0x013e1e, 0x013e1d, 0x013e1c, 0x013e1b, 0x013e1a, 0x013e19,
++    0x013e34, 0x013e33, 0x013e18, 0x013ec2, 0x013ec1, 0x013ece, 0x013edf, 0x013e17,
++    0x013ede, 0x013edd, 0x009d52, 0x009f18, 0x009f1b, 0x004eaa, 0x004ea8, 0x004fb1,
++    0x002753, 0x002757, 0x0013a8, 0x0013e0, 0x0013ee, 0x0009d6, 0x0004e9, 0x0004fa,
++    0x00027b, 0x00013c, 0x00009c, 0x00004d, 0x000021, 0x000012, 0x00000b, 0x000007,
++    0x000000, 0x000006, 0x00000a, 0x000011, 0x000020, 0x00004c, 0x00013f, 0x00013b,
++    0x00027a, 0x0004f9, 0x0004e8, 0x0009d7, 0x0013ef, 0x0013e2, 0x0027da, 0x0027c7,
++    0x002752, 0x004fb6, 0x004eac, 0x004eab, 0x009f65, 0x009d5a, 0x009d53, 0x013ecd,
++    0x013edc, 0x013ecc, 0x013ecf, 0x013ec9, 0x013e32, 0x013ec3, 0x013e16, 0x013ec0,
++    0x013ec8, 0x013e15, 0x013e14, 0x013e13, 0x013e12, 0x013e11, 0x013e10, 0x013ab7,
++    0x013ab6,
++};
++
++static const uint8_t acpl_hcb_gamma_coarse_dt_bits[41] = {
++    17, 17, 17, 17, 16, 17, 16, 16, 16, 15, 14, 13, 12, 12, 10,  9,
++     8,  7,  5,  3,  1,  2,  4,  7,  8, 10, 11, 12, 13, 13, 14, 15,
++    16, 16, 16, 17, 17, 17, 17, 17,  9,
++};
++
++static const uint32_t acpl_hcb_gamma_coarse_dt_codes[41] = {
++    0x00a7f3, 0x00a7f1, 0x00a7f9, 0x00a7f8, 0x0050e1, 0x00a7fe, 0x0050e8, 0x0050eb,
++    0x0053fe, 0x0029fd, 0x00143b, 0x000a1b, 0x00050c, 0x00053e, 0x000142, 0x0000a0,
++    0x000052, 0x00002b, 0x00000b, 0x000003, 0x000001, 0x000000, 0x000004, 0x00002a,
++    0x000051, 0x00014e, 0x00029e, 0x00050f, 0x000a7e, 0x000a1a, 0x001439, 0x002871,
++    0x0050ea, 0x0050e9, 0x0050e0, 0x00a7ff, 0x00a7fb, 0x00a7fa, 0x00a7f2, 0x00a7f0,
++    0x0000a6,
++};
++
++static const uint8_t acpl_hcb_gamma_fine_dt_bits[81] = {
++    18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 17,
++    17, 17, 17, 17, 16, 16, 16, 15, 15, 15, 14, 14, 13, 13, 12, 12,
++    11, 10,  9,  8,  7,  6,  5,  2,  1,  3,  5,  6,  7,  8, 10, 10,
++    11, 12, 13, 13, 14, 14, 15, 15, 15, 15, 16, 16, 17, 17, 17, 17,
++    17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18,
++    18,
++};
++
++static const uint32_t acpl_hcb_gamma_fine_dt_codes[81] = {
++    0x031e44, 0x031d1d, 0x031e42, 0x031e16, 0x031e41, 0x031e47, 0x031d1c, 0x031e43,
++    0x031e73, 0x031e72, 0x031e15, 0x031e70, 0x031e75, 0x031e7f, 0x031e7e, 0x018e88,
++    0x018d8b, 0x018e8f, 0x018f0e, 0x018f3e, 0x00c746, 0x00c796, 0x00c79e, 0x006361,
++    0x0063c9, 0x0063d8, 0x0031d0, 0x0031e6, 0x0018d9, 0x0018f1, 0x000c6d, 0x000c7a,
++    0x00063b, 0x00031c, 0x00018c, 0x0000c1, 0x000062, 0x000033, 0x00001b, 0x000002,
++    0x000000, 0x000007, 0x00001a, 0x000032, 0x000061, 0x0000c0, 0x00031f, 0x00031a,
++    0x000637, 0x000c75, 0x0018f7, 0x0018e9, 0x0031ed, 0x0031e0, 0x0063d9, 0x0063ca,
++    0x006363, 0x006360, 0x00c786, 0x00c745, 0x018f3b, 0x018f2e, 0x018e89, 0x018d88,
++    0x018d8a, 0x018d89, 0x031e5f, 0x031e74, 0x031e40, 0x031e71, 0x031e46, 0x031e5e,
++    0x031e1f, 0x031e45, 0x031e1e, 0x031e14, 0x031e17, 0x031e13, 0x031e12, 0x031e11,
++    0x031e10,
++};
++
++DECLARE_ASM_CONST(32, float, qwin)[640] = {
++    0,
++    1.990318758627504e-004,  2.494762615491542e-004,  3.021769445225078e-004,
++    3.548460080857985e-004,  4.058915811480806e-004,  4.546408052001889e-004,
++    5.012680176678405e-004,  5.464958142195282e-004,  5.912073950641334e-004,
++    6.361178026937039e-004,  6.816060488244358e-004,  7.277257095064290e-004,
++    7.743418255606097e-004,  8.212990636826637e-004,  8.685363488152327e-004,
++    9.161071539925993e-004,  9.641168291303352e-004,  1.012630507392736e-003,
++    1.061605258108620e-003,  1.110882587090581e-003,  1.160236901298543e-003,
++    1.209448942573337e-003,  1.258362795150757e-003,  1.306902381715039e-003,
++    1.355046337751365e-003,  1.402784629568410e-003,  1.450086694843816e-003,
++    1.496898951224534e-003,  1.543170821958483e-003,  1.588889089195869e-003,
++    1.634098242730728e-003,  1.678892372493930e-003,  1.723381173920660e-003,
++    1.767651163797991e-003,  1.811741998614740e-003,  1.855650606587200e-003,
++    1.899360915083620e-003,  1.942876625831283e-003,  1.986241654706626e-003,
++    2.029534125962055e-003,  2.072840712410525e-003,  2.116229103721749e-003,
++    2.159738034390673e-003,  2.203392976200947e-003,  2.247239773881968e-003,
++    2.291373966775394e-003,  2.335946110021889e-003,  2.381132815654862e-003,
++    2.427086732976290e-003,  2.473891839822582e-003,  2.521550367974952e-003,
++    2.570013995199655e-003,  2.619244058999978e-003,  2.669265893796866e-003,
++    2.720177146231281e-003,  2.772088849679780e-003,  2.825009494162980e-003,
++    2.878716544061140e-003,  2.932677076291194e-003,  2.986067366389476e-003,
++    3.037905983043366e-003,  3.087269477594307e-003,  3.133519274378684e-003,
++    3.176460810085721e-003,  3.216374095471449e-003,  3.253902493849856e-003,
++    3.289837867273167e-003,  3.324873276103132e-003,  3.359407689115599e-003,
++    3.393454084675361e-003,  3.426668323773391e-003,  3.458465815999750e-003,
++    3.488171121469781e-003,  3.515141351338780e-003,  3.538827383683883e-003,
++    3.558767785536742e-003,  3.574539247363964e-003,  3.585697968628984e-003,
++    3.591743339500398e-003,  3.592116764752254e-003,  3.586228204993297e-003,
++    3.573492966885132e-003,  3.553356715665694e-003,  3.525300399274114e-003,
++    3.488824092931520e-003,  3.443423145747434e-003,  3.388568319085867e-003,
++    3.323699442173841e-003,  3.248231770523395e-003,  3.161568930730635e-003,
++    3.063113666967670e-003,  2.952270973359112e-003,  2.828441943181057e-003,
++    2.691016173288500e-003,  2.539366102140493e-003,  2.372848583221744e-003,
++    2.190814088754598e-003,  1.992618085548526e-003,  1.777631090142623e-003,
++    1.545242163079598e-003,  1.294855985911958e-003,  1.025885587325796e-003,
++    7.377456851538827e-004,  4.298496740962311e-004,  1.016113723823784e-004,
++   -2.475493814535340e-004, -6.181972580227641e-004, -1.010876063031582e-003,
++   -1.426108207321696e-003, -1.864392667409557e-003, -2.326207721179968e-003,
++   -2.812013688448634e-003, -3.322252633537029e-003, -3.857344314546718e-003,
++   -4.417678415707104e-003, -5.003604409245843e-003, -5.615422427540850e-003,
++   -6.253382198869787e-003, -6.917691380307223e-003, -7.608536937561301e-003,
++   -8.326113472848559e-003, -9.070651572928327e-003, -9.842433610911637e-003,
++   -1.064178450184536e-002, -1.146903570409307e-002, -1.232446526717138e-002,
++   -1.320822893615923e-002,  1.412030102138547e-002,  1.506045143737221e-002,
++    1.602824700934038e-002,  1.702310507234504e-002,  1.804435938034114e-002,
++    1.909132707403387e-002,  2.016335321815832e-002,  2.125982139139435e-002,
++    2.238013015948307e-002,  2.352365148441367e-002,  2.468968228813486e-002,
++    2.587741357605385e-002,  2.708591966384863e-002,  2.831416731612567e-002,
++    2.956103453432552e-002,  3.082532788511644e-002,  3.210578787607558e-002,
++    3.340108247607704e-002,  3.470979250147262e-002,  3.603039785904666e-002,
++    3.736126987823528e-002,  3.870067428980750e-002,  4.004677994303860e-002,
++    4.139766786359423e-002,  4.275134353925827e-002,  4.410572893128047e-002,
++    4.545866171224587e-002,  4.680788921400311e-002,  4.815106534667384e-002,
++    4.948575188369231e-002,  5.080942296260306e-002,  5.211947012173918e-002,
++    5.341320372603929e-002,  5.468785186395163e-002,  5.594055607104873e-002,
++    5.716836923188953e-002,  5.836825629443718e-002,  5.953709945765930e-002,
++    6.067170625396996e-002,  6.176881705202805e-002,  6.282510999827461e-002,
++    6.383720245755561e-002,  6.480165083585107e-002,  6.571495100350305e-002,
++    6.657354346196487e-002,  6.737381445564891e-002,  6.811211000439976e-002,
++    6.878473991370719e-002,  6.938797895654626e-002,  6.991806618580000e-002,
++    7.037120381110623e-002,  7.074355866301176e-002,  7.103126866531538e-002,
++    7.123045563399449e-002,  7.133723888151840e-002,  7.134774334517399e-002,
++    7.125810128129656e-002,  7.106444395777428e-002,  7.076288963679085e-002,
++    7.034953453342756e-002,  6.982045490146145e-002,  6.917172452383333e-002,
++    6.839944399575645e-002,  6.749977716975542e-002,  6.646898181809889e-002,
++    6.530342654389224e-002,  6.399958984339946e-002,  6.255404354954748e-002,
++    6.096342863203985e-002,  5.922443337469448e-002,  5.733378365410422e-002,
++    5.528824660015738e-002,  5.308464739461209e-002,  5.071989148277166e-002,
++    4.819098634672628e-002,  4.549505579582869e-002,  4.262934676625042e-002,
++    3.959122947020497e-002,  3.637819581239452e-002,  3.298786054608736e-002,
++    2.941796954479800e-002,  2.566640058060906e-002,  2.173117939155709e-002,
++    1.761048656968719e-002,  1.330266415707108e-002,  8.806217289921706e-003,
++    4.119815918461287e-003, -7.577038291607129e-004, -5.827337082489678e-003,
++   -1.108990619665782e-002, -1.654605559674886e-002, -2.219624707735291e-002,
++   -2.804075556277473e-002, -3.407966641908426e-002, -4.031287253355741e-002,
++   -4.674007190475649e-002, -5.336076390182971e-002, -6.017424526940620e-002,
++   -6.717960594283154e-002, -7.437572538762392e-002, -8.176127022450692e-002,
++   -8.933469320120192e-002, -9.709423309043450e-002, -1.050379143754414e-001,
++   -1.131635475471188e-001, -1.214687284677367e-001, -1.299508386078101e-001,
++   -1.386070430802319e-001, -1.474342913196958e-001, -1.564293167898782e-001,
++   -1.655886374953163e-001, -1.749085568711785e-001, -1.843851642116290e-001,
++   -1.940143360850268e-001, -2.037917371113644e-001, -2.137128217101543e-001,
++   -2.237728356363325e-001, -2.339668182208061e-001, -2.442896055908444e-001,
++   -2.547358344658102e-001, -2.652999476893712e-001, -2.759762003673840e-001,
++   -2.867586659726799e-001, -2.976412485679301e-001, -3.086176827721830e-001,
++   -3.196815399704708e-001, -3.308262316588501e-001, -3.420450091826495e-001,
++    3.533309414505971e-001,  3.646770149404552e-001,  3.760759747758828e-001,
++    3.875204555118187e-001,  3.990029533969267e-001,  4.105158411581483e-001,
++    4.220513789540003e-001,  4.336017251305980e-001,  4.451589452332786e-001,
++    4.567150149423557e-001,  4.682618290579831e-001,  4.797912086537587e-001,
++    4.912949058677955e-001,  5.027646134968753e-001,  5.141919746376279e-001,
++    5.255685924518015e-001,  5.368860394090674e-001,  5.481358656081351e-001,
++    5.593096071830315e-001,  5.703987947306394e-001,  5.813949615434598e-001,
++    5.922896536434017e-001,  6.030744392774144e-001,  6.137409201916185e-001,
++    6.242807411441345e-001,  6.346855991963545e-001,  6.449472531836600e-001,
++    6.550575323798634e-001,  6.650083455855346e-001,  6.747916901830467e-001,
++    6.843996616799759e-001,  6.938244627003839e-001,  7.030584122393319e-001,
++    7.120939537241190e-001,  7.209236637533725e-001,  7.295402599029810e-001,
++    7.379366091028713e-001,  7.461057359576386e-001,  7.540408314942230e-001,
++    7.617352611504460e-001,  7.691825714586890e-001,  7.763765020733762e-001,
++    7.833109874824341e-001,  7.899801646390305e-001,  7.963783815797485e-001,
++    8.025002033685581e-001,  8.083404191294724e-001,  8.138940486031526e-001,
++    8.191563476989879e-001,  8.241228138607196e-001,  8.287891904413357e-001,
++    8.331514714928793e-001,  8.372059062705359e-001,  8.409490040631689e-001,
++    8.443775395556067e-001,  8.474885573145614e-001,  8.502793750759253e-001,
++    8.527475863595390e-001,  8.548910606594570e-001,  8.567079441260879e-001,
++    8.581966597760032e-001,  8.593559096378087e-001,  8.601846769933608e-001,
++    8.606822313166693e-001,  8.608481078185764e-001,  8.606822313166693e-001,
++    8.601846769933608e-001,  8.593559096378087e-001,  8.581966597760032e-001,
++    8.567079441260879e-001,  8.548910606594570e-001,  8.527475863595390e-001,
++    8.502793750759253e-001,  8.474885573145614e-001,  8.443775395556067e-001,
++    8.409490040631689e-001,  8.372059062705359e-001,  8.331514714928793e-001,
++    8.287891904413357e-001,  8.241228138607196e-001,  8.191563476989879e-001,
++    8.138940486031526e-001,  8.083404191294724e-001,  8.025002033685581e-001,
++    7.963783815797485e-001,  7.899801646390305e-001,  7.833109874824341e-001,
++    7.763765020733762e-001,  7.691825714586890e-001,  7.617352611504460e-001,
++    7.540408314942230e-001,  7.461057359576386e-001,  7.379366091028713e-001,
++    7.295402599029810e-001,  7.209236637533725e-001,  7.120939537241190e-001,
++    7.030584122393319e-001,  6.938244627003839e-001,  6.843996616799759e-001,
++    6.747916901830467e-001,  6.650083455855346e-001,  6.550575323798634e-001,
++    6.449472531836600e-001,  6.346855991963545e-001,  6.242807411441345e-001,
++    6.137409201916185e-001,  6.030744392774144e-001,  5.922896536434017e-001,
++    5.813949615434598e-001,  5.703987947306394e-001,  5.593096071830315e-001,
++    5.481358656081351e-001,  5.368860394090674e-001,  5.255685924518015e-001,
++    5.141919746376279e-001,  5.027646134968753e-001,  4.912949058677955e-001,
++    4.797912086537587e-001,  4.682618290579831e-001,  4.567150149423557e-001,
++    4.451589452332786e-001,  4.336017251305980e-001,  4.220513789540003e-001,
++    4.105158411581483e-001,  3.990029533969267e-001,  3.875204555118187e-001,
++    3.760759747758828e-001,  3.646770149404552e-001, -3.533309414505971e-001,
++   -3.420450091826495e-001, -3.308262316588501e-001, -3.196815399704708e-001,
++   -3.086176827721830e-001, -2.976412485679301e-001, -2.867586659726799e-001,
++   -2.759762003673840e-001, -2.652999476893712e-001, -2.547358344658102e-001,
++   -2.442896055908444e-001, -2.339668182208061e-001, -2.237728356363325e-001,
++   -2.137128217101543e-001, -2.037917371113644e-001, -1.940143360850268e-001,
++   -1.843851642116290e-001, -1.749085568711785e-001, -1.655886374953163e-001,
++   -1.564293167898782e-001, -1.474342913196958e-001, -1.386070430802319e-001,
++   -1.299508386078101e-001, -1.214687284677367e-001, -1.131635475471188e-001,
++   -1.050379143754414e-001, -9.709423309043450e-002, -8.933469320120192e-002,
++   -8.176127022450692e-002, -7.437572538762392e-002, -6.717960594283154e-002,
++   -6.017424526940620e-002, -5.336076390182971e-002, -4.674007190475649e-002,
++   -4.031287253355741e-002, -3.407966641908426e-002, -2.804075556277473e-002,
++   -2.219624707735291e-002, -1.654605559674886e-002, -1.108990619665782e-002,
++   -5.827337082489678e-003, -7.577038291607129e-004,  4.119815918461287e-003,
++    8.806217289921706e-003,  1.330266415707108e-002,  1.761048656968719e-002,
++    2.173117939155709e-002,  2.566640058060906e-002,  2.941796954479800e-002,
++    3.298786054608736e-002,  3.637819581239452e-002,  3.959122947020497e-002,
++    4.262934676625042e-002,  4.549505579582869e-002,  4.819098634672628e-002,
++    5.071989148277166e-002,  5.308464739461209e-002,  5.528824660015738e-002,
++    5.733378365410422e-002,  5.922443337469448e-002,  6.096342863203985e-002,
++    6.255404354954748e-002,  6.399958984339946e-002,  6.530342654389224e-002,
++    6.646898181809889e-002,  6.749977716975542e-002,  6.839944399575645e-002,
++    6.917172452383333e-002,  6.982045490146145e-002,  7.034953453342756e-002,
++    7.076288963679085e-002,  7.106444395777428e-002,  7.125810128129656e-002,
++    7.134774334517399e-002,  7.133723888151840e-002,  7.123045563399449e-002,
++    7.103126866531538e-002,  7.074355866301176e-002,  7.037120381110623e-002,
++    6.991806618580000e-002,  6.938797895654626e-002,  6.878473991370719e-002,
++    6.811211000439976e-002,  6.737381445564891e-002,  6.657354346196487e-002,
++    6.571495100350305e-002,  6.480165083585107e-002,  6.383720245755561e-002,
++    6.282510999827461e-002,  6.176881705202805e-002,  6.067170625396996e-002,
++    5.953709945765930e-002,  5.836825629443718e-002,  5.716836923188953e-002,
++    5.594055607104873e-002,  5.468785186395163e-002,  5.341320372603929e-002,
++    5.211947012173918e-002,  5.080942296260306e-002,  4.948575188369231e-002,
++    4.815106534667384e-002,  4.680788921400311e-002,  4.545866171224587e-002,
++    4.410572893128047e-002,  4.275134353925827e-002,  4.139766786359423e-002,
++    4.004677994303860e-002,  3.870067428980750e-002,  3.736126987823528e-002,
++    3.603039785904666e-002,  3.470979250147262e-002,  3.340108247607704e-002,
++    3.210578787607558e-002,  3.082532788511644e-002,  2.956103453432552e-002,
++    2.831416731612567e-002,  2.708591966384863e-002,  2.587741357605385e-002,
++    2.468968228813486e-002,  2.352365148441367e-002,  2.238013015948307e-002,
++    2.125982139139435e-002,  2.016335321815832e-002,  1.909132707403387e-002,
++    1.804435938034114e-002,  1.702310507234504e-002,  1.602824700934038e-002,
++    1.506045143737221e-002, -1.412030102138547e-002, -1.320822893615923e-002,
++   -1.232446526717138e-002, -1.146903570409307e-002, -1.064178450184536e-002,
++   -9.842433610911637e-003, -9.070651572928327e-003, -8.326113472848559e-003,
++   -7.608536937561301e-003, -6.917691380307223e-003, -6.253382198869787e-003,
++   -5.615422427540850e-003, -5.003604409245843e-003, -4.417678415707104e-003,
++   -3.857344314546718e-003, -3.322252633537029e-003, -2.812013688448634e-003,
++   -2.326207721179968e-003, -1.864392667409557e-003, -1.426108207321696e-003,
++   -1.010876063031582e-003, -6.181972580227641e-004, -2.475493814535340e-004,
++    1.016113723823784e-004,  4.298496740962311e-004,  7.377456851538827e-004,
++    1.025885587325796e-003,  1.294855985911958e-003,  1.545242163079598e-003,
++    1.777631090142623e-003,  1.992618085548526e-003,  2.190814088754598e-003,
++    2.372848583221744e-003,  2.539366102140493e-003,  2.691016173288500e-003,
++    2.828441943181057e-003,  2.952270973359112e-003,  3.063113666967670e-003,
++    3.161568930730635e-003,  3.248231770523395e-003,  3.323699442173841e-003,
++    3.388568319085867e-003,  3.443423145747434e-003,  3.488824092931520e-003,
++    3.525300399274114e-003,  3.553356715665694e-003,  3.573492966885132e-003,
++    3.586228204993297e-003,  3.592116764752254e-003,  3.591743339500398e-003,
++    3.585697968628984e-003,  3.574539247363964e-003,  3.558767785536742e-003,
++    3.538827383683883e-003,  3.515141351338780e-003,  3.488171121469781e-003,
++    3.458465815999750e-003,  3.426668323773391e-003,  3.393454084675361e-003,
++    3.359407689115599e-003,  3.324873276103132e-003,  3.289837867273167e-003,
++    3.253902493849856e-003,  3.216374095471449e-003,  3.176460810085721e-003,
++    3.133519274378684e-003,  3.087269477594307e-003,  3.037905983043366e-003,
++    2.986067366389476e-003,  2.932677076291194e-003,  2.878716544061140e-003,
++    2.825009494162980e-003,  2.772088849679780e-003,  2.720177146231281e-003,
++    2.669265893796866e-003,  2.619244058999978e-003,  2.570013995199655e-003,
++    2.521550367974952e-003,  2.473891839822582e-003,  2.427086732976290e-003,
++    2.381132815654862e-003,  2.335946110021889e-003,  2.291373966775394e-003,
++    2.247239773881968e-003,  2.203392976200947e-003,  2.159738034390673e-003,
++    2.116229103721749e-003,  2.072840712410525e-003,  2.029534125962055e-003,
++    1.986241654706626e-003,  1.942876625831283e-003,  1.899360915083620e-003,
++    1.855650606587200e-003,  1.811741998614740e-003,  1.767651163797991e-003,
++    1.723381173920660e-003,  1.678892372493930e-003,  1.634098242730728e-003,
++    1.588889089195869e-003,  1.543170821958483e-003,  1.496898951224534e-003,
++    1.450086694843816e-003,  1.402784629568410e-003,  1.355046337751365e-003,
++    1.306902381715039e-003,  1.258362795150757e-003,  1.209448942573337e-003,
++    1.160236901298543e-003,  1.110882587090581e-003,  1.061605258108620e-003,
++    1.012630507392736e-003,  9.641168291303352e-004,  9.161071539925993e-004,
++    8.685363488152327e-004,  8.212990636826637e-004,  7.743418255606097e-004,
++    7.277257095064290e-004,  6.816060488244358e-004,  6.361178026937039e-004,
++    5.912073950641334e-004,  5.464958142195282e-004,  5.012680176678405e-004,
++    4.546408052001889e-004,  4.058915811480806e-004,  3.548460080857985e-004,
++    3.021769445225078e-004,  2.494762615491542e-004,  1.990318758627504e-004,
++};
++
++static const float new_chirp_tab[4][4] = {
++    { 0.0,  0.6,  0.0,  0.0,  },
++    { 0.6,  0.75, 0.75, 0.75, },
++    { 0.9,  0.9,  0.9,  0.9,  },
++    { 0.98, 0.98, 0.98, 0.98, },
++};
++
++static const int8_t aspx_sine[2][4] = {
++    { 1, 0, -1,  0 }, { 0, 1,  0, -1 },
++};
++
++static const float aspx_noise[512][2] = {
++    {-0.782083, -0.623174}, { 0.705088, -0.70912}, { 0.268786, -0.9632},
++    { 0.689305, -0.724471}, {-0.0430946, -0.999071}, {-0.998077, -0.0619922},
++    { 0.867875, -0.496783}, { 0.814907, -0.579591}, { 0.880168, 0.474663},
++    {-0.39062, -0.920552}, { 0.0434465, 0.999056}, { 0.610173, -0.792268},
++    {-0.942195, 0.335065}, {-0.911161, 0.412052}, {-0.999084, -0.0427925},
++    {-0.811795, 0.583942}, { 0.836524, 0.54793}, { 0.475443, 0.879747},
++    { 0.961597, -0.274466}, { 0.820146, 0.572155}, {-0.498318, -0.866994},
++    { 0.825586, -0.564277}, { 0.999973, 0.00730176}, { 0.895923, 0.44421},
++    {-0.80517, -0.593044}, { 0.277753, 0.960652}, {-0.999688, 0.0249582},
++    {-0.802608, -0.596507}, { 0.936737, -0.350035}, {-0.997477, -0.0709933},
++    {-0.674713, -0.73808}, {-0.957686, -0.287817}, { 0.983532, 0.180732},
++    { 0.634759, -0.77271}, {-0.150723, -0.988576}, {-0.113979, 0.993483},
++    {-0.993827, -0.110942}, { 0.781536, 0.62386}, {-0.615104, -0.788446},
++    {-0.586834, 0.809707}, {-0.226253, 0.974069}, { 0.949896, -0.312565},
++    { 0.830084, 0.557638}, { 0.60415, 0.796871}, { 0.655412, 0.755272},
++    {-0.916524, -0.399979}, { 0.763757, -0.645503}, { 0.822298, 0.569058},
++    {-0.0283442, -0.999598}, {-0.644058, -0.764977}, {-0.390833, -0.920462},
++    {-0.984217, -0.176967}, { 0.719987, 0.693987}, { 0.999088, -0.042707},
++    { 0.754487, 0.656315}, { 0.498312, 0.866998}, { 0.999389, 0.0349481},
++    {-0.811845, -0.583873}, { 0.532015, -0.846735}, {-0.463781, 0.88595},
++    {-0.819481, -0.573106}, { 0.637789, 0.770211}, { 0.814253, -0.58051},
++    { 0.180489, -0.983577}, { 0.988691, -0.149968}, { 0.606847, -0.794819},
++    {-0.061914, 0.998081}, { 0.627066, 0.778966}, {-0.544097, -0.839023},
++    {-0.859249, -0.511558}, {-0.91818, 0.396163}, {-0.165942, 0.986136},
++    { 0.992322, 0.123685}, { 0.758555, 0.651609}, { 0.985543, -0.169427},
++    {-0.154971, -0.987919}, { 0.245336, 0.969438}, {-0.522038, -0.852922},
++    {-0.33027, -0.943886}, { 0.998067, -0.0621421}, { 0.516758, 0.856132},
++    { 0.843123, -0.537721}, { 0.44306, 0.896492}, {-0.814913, 0.579584},
++    {-0.336464, -0.941696}, { 0.732896, 0.68034}, { 0.201774, -0.979432},
++    { 0.741954, 0.670451}, {-0.469083, 0.883154}, { 0.867784, 0.496941},
++    { 0.494202, -0.869347}, { 0.9367, -0.350134}, { 0.906328, 0.422575},
++    { 0.764111, 0.645085}, { 0.631052, -0.77574}, {-0.0498248, -0.998758},
++    { 0.974691, -0.223555}, { 0.361405, -0.932409}, {-0.748625, 0.662994},
++    { 0.811839, -0.583881}, { 0.303931, 0.952694}, {-0.992668, -0.120876},
++    {-0.996672, -0.0815161}, {-0.324622, 0.945844}, {-0.0246385, -0.999696},
++    {-0.588361, 0.808598}, {-0.49898, 0.866613}, { 0.924578, -0.380994},
++    {-0.755619, 0.655011}, { 0.92214, -0.386857}, { 0.818638, 0.57431},
++    {-0.920451, 0.390857}, { 0.0380205, -0.999277}, { 0.446606, -0.894731},
++    { 0.722557, -0.691312}, { 0.762113, -0.647444}, {-0.256731, -0.966483},
++    { 0.471301, -0.881972}, {-0.530869, -0.847454}, {-0.749876, 0.661579},
++    {-0.593767, -0.804637}, {-0.834805, 0.550545}, { 0.748843, 0.662747},
++    {-0.70794, 0.706273}, {-0.0503228, -0.998733}, { 0.402884, -0.915251},
++    { 0.0945791, -0.995517}, {-0.390889, -0.920438}, {-0.0994705, -0.995041},
++    {-0.767207, -0.641399}, {-0.563485, -0.826126}, {-0.521859, 0.853032},
++    { 0.503637, 0.863915}, {-0.739851, -0.672771}, { 0.442624, -0.896707},
++    {-0.997671, 0.0682121}, { 0.776117, -0.630589}, {-0.964601, -0.263713},
++    {-0.656053, 0.754715}, {-0.865578, 0.500775}, {-0.586255, -0.810127},
++    { 0.0425286, -0.999095}, { 0.656339, 0.754466}, {-0.341906, 0.939734},
++    {-0.605904, 0.795538}, {-0.658238, -0.752809}, {-0.652856, 0.757482},
++    {-0.994554, 0.104219}, { 0.176725, -0.98426}, {-0.231945, 0.972729},
++    {-0.997717, -0.0675303}, {-0.997805, 0.0662198}, { 0.661155, 0.75025},
++    { 0.999669, -0.02573}, {-0.946982, -0.321287}, {-0.587897, 0.808936},
++    { 0.957862, -0.28723}, { 0.613392, -0.789779}, {-0.956489, 0.291768},
++    { 0.169829, -0.985474}, {-0.943551, -0.331226}, { 0.416834, 0.908983},
++    { 0.684727, -0.7288}, { 0.952329, 0.305074}, {-0.328392, 0.944541},
++    { 0.943344, 0.331816}, { 0.650872, 0.759187}, {-0.59941, -0.800442},
++    {-0.768448, -0.639912}, { 0.539894, 0.841733}, { 0.606048, -0.795428},
++    { 0.403588, 0.914941}, {-0.838111, 0.545499}, { 0.976157, -0.217066},
++    {-0.995495, -0.0948107}, {-0.943792, 0.330539}, {-0.990415, 0.138123},
++    { 0.281355, 0.959604}, { 0.371208, 0.92855}, {-0.4711, 0.88208},
++    {-0.999459, -0.0328787}, {-0.988179, 0.153305}, {-0.843124, -0.537718},
++    { 0.997108, 0.0759971}, {-0.268201, -0.963363}, { 0.0457651, 0.998952},
++    {-0.983762, 0.179479}, {-0.439728, -0.898131}, { 0.162945, -0.986635},
++    {-0.055868, 0.998438}, {-0.384381, 0.923174}, { 0.744138, -0.668026},
++    {-0.0706482, -0.997501}, { 0.831219, 0.555945}, { 0.711624, 0.70256},
++    { 0.161772, -0.986828}, { 0.8387, 0.544593}, {-0.418108, 0.908397},
++    { 0.412208, 0.91109}, {-0.986564, 0.163375}, { 0.925222, 0.379427},
++    { 0.411092, -0.911594}, {-0.103885, -0.994589}, {-0.923358, -0.383941},
++    {-0.761339, 0.648355}, {-0.887774, -0.46028}, { 0.755699, -0.654919},
++    { 0.597832, -0.801622}, { 0.542946, -0.839768}, { 0.999842, -0.0177525},
++    {-0.954864, 0.297044}, {-0.999961, -0.00886517}, { 0.929688, -0.368347},
++    { 0.699205, 0.714921}, {-0.894118, 0.447831}, {-0.903496, 0.428597},
++    { 0.362774, -0.931877}, { 0.850158, -0.526527}, { 0.523993, -0.851722},
++    {-0.735767, 0.677235}, {-0.999673, -0.02558}, {-0.954685, 0.297619},
++    {-0.195193, -0.980765}, { 0.0672577, -0.997736}, {-0.659842, -0.751405},
++    { 0.779366, 0.626569}, { 0.751561, -0.659663}, {-0.34458, -0.938757},
++    { 0.316872, 0.948468}, { 0.953601, 0.301074}, { 0.363243, 0.931694},
++    {-0.537299, -0.843392}, { 0.996839, 0.0794518}, { 0.950462, -0.310842},
++    { 0.224973, 0.974365}, {-0.772894, -0.634535}, {-0.94373, -0.330718},
++    { 0.930603, 0.36603}, { 0.994059, 0.10884}, { 0.845518, -0.533947},
++    { 0.988122, -0.15367}, { 0.880641, -0.473785}, { 0.783488, -0.621407},
++    { 0.72854, 0.685004}, {-0.772294, 0.635265}, { 0.662444, 0.749111},
++    {-0.0649291, 0.99789}, {-0.285125, 0.95849}, {-0.673637, -0.739062},
++    {-0.394791, -0.918771}, {-0.938677, -0.344798}, {-0.708925, -0.705284},
++    { 0.31416, 0.94937}, {-0.113645, 0.993521}, {-0.296446, 0.95505},
++    { 0.670712, -0.741718}, {-0.605825, 0.795598}, { 0.996229, 0.0867643},
++    { 0.686613, -0.727023}, {-0.740136, 0.672457}, { 0.876977, 0.480532},
++    {-0.561046, 0.827785}, { 0.414562, -0.910021}, {-0.645953, -0.763377},
++    { 0.802263, 0.596971}, {-0.854981, 0.51866}, {-0.769916, 0.638145}, { 0.648047, 0.7616},
++    {-0.773406, 0.633911}, {-0.252579, -0.967576}, { 0.962561, -0.271064},
++    { 0.959193, -0.282751}, { 0.727508, 0.686099}, {-0.667916, 0.744236},
++    {-0.599333, 0.8005}, { 0.622504, 0.782616}, { 0.375433, -0.92685},
++    {-0.9972, 0.0747742}, {-0.879355, 0.476166}, { 0.409574, 0.912277},
++    { 0.747405, -0.664369}, {-0.940177, -0.340687}, { 0.562532, 0.826776},
++    {-0.929015, 0.370041}, { 0.0978642, 0.9952}, { 0.916896, -0.399125},
++    {-0.608038, -0.793908}, {-0.845653, -0.533732}, {-0.455945, -0.890008},
++    { 0.923484, -0.383637}, { 0.354901, 0.934904}, { 0.319134, -0.94771},
++    { 0.769603, -0.638523}, {-0.899207, 0.437524}, { 0.666669, -0.745354},
++    { 0.142655, -0.989772}, {-0.892, -0.452035}, {-0.999915, -0.0130018},
++    {-0.87033, 0.492469}, { 0.156511, 0.987676}, {-0.146752, 0.989173},
++    {-0.809057, 0.58773}, {-0.497325, -0.867565}, {-0.258455, -0.966023},
++    {-0.863292, -0.504705}, {-0.976343, -0.216225}, {-0.257626, -0.966245},
++    { 0.809568, -0.587027}, { 0.582491, 0.812837}, {-0.997088, -0.0762565},
++    {-0.878262, 0.47818}, {-0.165343, -0.986236}, { 0.0455161, 0.998964},
++    {-0.570664, 0.821184}, { 0.658564, 0.752525}, { 0.319839, -0.947472},
++    {-0.643905, -0.765106}, {-0.590256, 0.807216}, { 0.512137, 0.858904},
++    {-0.998558, 0.0536785}, { 0.373964, -0.927443}, { 0.633108, -0.774063},
++    {-0.968108, 0.250531}, { 0.787337, 0.616523}, { 0.698247, -0.715857},
++    { 0.98937, 0.145419}, { 0.582241, -0.813016}, { 0.359617, 0.9331},
++    {-0.758164, -0.652064}, { 0.635102, 0.772429}, {-0.0254028, -0.999677},
++    { 0.266382, -0.963868}, { 0.660974, -0.750409}, { 0.585176, -0.810906},
++    {-0.98243, 0.186631}, { 0.777252, -0.629189}, {-0.0267382, 0.999642},
++    {-0.95591, 0.293661}, { 0.70368, -0.710517}, { 0.732467, -0.680803},
++    { 0.854099, -0.52011}, { 0.536151, 0.844122}, {-0.00781503, 0.999969},
++    {-0.534447, 0.845202}, { 0.297782, 0.954634}, { 0.905724, 0.423868},
++    { 0.115617, -0.993294}, {-0.993408, -0.114636}, { 0.156977, 0.987602},
++    { 0.639408, -0.768868}, {-0.995898, 0.0904832}, {-0.956372, 0.29215},
++    { 0.990545, 0.137189}, { 0.659118, 0.75204}, {-0.0398563, -0.999205},
++    {-0.679682, -0.733507}, {-0.540035, 0.841643}, {-0.0501135, -0.998744},
++    {-0.196305, -0.980543}, { 0.56964, 0.821894}, {-0.703653, 0.710544},
++    { 0.162676, -0.98668}, {-0.919545, 0.392984}, { 0.805179, 0.593031},
++    { 0.998757, 0.0498406}, { 0.358168, 0.933657}, {-0.611152, -0.791513},
++    {-0.440479, 0.897763}, { 0.292587, 0.956239}, {-0.217415, -0.976079},
++    {-0.252622, -0.967565}, {-0.679998, -0.733214}, { 0.402652, -0.915353},
++    {-0.993189, 0.116516}, { 0.0634956, 0.997982}, { 0.432309, -0.901725},
++    { 0.923434, 0.383756}, {-0.502058, 0.864834}, { 0.935584, -0.353105},
++    { 0.912111, -0.409944}, {-0.298643, 0.954365}, {-0.796165, 0.60508},
++    {-0.741295, -0.671179}, { 0.856386, 0.516336}, {-0.515876, -0.856663},
++    { 0.994745, -0.102384}, { 0.648698, -0.761046}, {-0.999675, -0.0254761},
++    {-0.130115, 0.991499}, {-0.998787, 0.0492413}, { 0.27449, -0.96159},
++    {-0.996501, -0.0835749}, {-0.387182, 0.922003}, { 0.701006, -0.713156},
++    { 0.98733, -0.158679}, {-0.713847, 0.700302}, {-0.329606, 0.944118},
++    { 0.279362, 0.960186}, {-0.968574, -0.248726}, {-0.68131, 0.731995},
++    { 0.220789, -0.975322}, {-0.985566, -0.169292}, { 0.0132834, 0.999912},
++    {-0.422317, 0.906448}, {-0.772023, -0.635594}, { 0.842036, -0.539421},
++    {-0.803312, 0.595558}, { 0.725035, 0.688712}, { 0.328206, 0.944606},
++    { 0.711898, 0.702283}, {-0.691674, 0.72221}, {-0.871274, 0.490797},
++    { 0.213736, 0.976891}, { 0.255845, 0.966718}, { 0.883381, 0.468656}, {-0.596736, 0.802437},
++    { 0.779861, 0.625953}, {-0.607233, 0.794524}, {-0.944679, -0.327996},
++    { 0.851219, -0.52481}, {-0.859337, -0.51141}, { 0.953486, -0.301437},
++    { 0.512244, -0.85884}, { 0.160393, 0.987053}, { 0.752002, 0.659161},
++    { 0.999882, 0.0153624}, { 0.778011, -0.628251}, { 0.9293, -0.369326},
++    {-0.605896, 0.795544}, { 0.633164, 0.774017}, {-0.923382, -0.383883},
++    {-0.790911, 0.611931}, { 0.673492, 0.739195}, {-0.784902, 0.61962},
++    { 0.289472, 0.957187}, { 0.605387, -0.795931}, {-0.459844, -0.888},
++    {-0.990035, 0.140822}, {-0.686367, -0.727256}, {-0.549857, 0.835259},
++    { 0.90982, 0.415003}, {-0.42105, 0.907037}, {-0.07295, 0.997336},
++    {-0.24021, 0.970721}, { 0.993154, -0.116813}, {-0.59563, -0.803259},
++    { 0.526545, -0.850147}, { 0.9987, -0.0509667}, {-0.85017, -0.526508},
++    {-0.818838, -0.574025}, { 0.982094, 0.188394}, { 0.577634, -0.816296},
++    {-0.418394, -0.908265}, { 0.62868, -0.777664}, {-0.118173, -0.992993},
++    { 0.896113, 0.443827}, {-0.159857, -0.98714}, { 0.750036, 0.661397},
++    { 0.745659, 0.666328}, {-0.938865, -0.344285}, {-0.583143, 0.812369},
++    { 0.479122, 0.877748}, {-0.869898, -0.493231}, {-0.791797, 0.610784}, { 0.35785, 0.933779},
++    { 0.25248, -0.967602}, {-0.573942, -0.818896}, {-0.930426, -0.366479},
++    {-0.378158, 0.925741}, {-0.942114, 0.335293}, { 0.647836, -0.76178},
++    { 0.814174, 0.580622}, { 0.023769, 0.999717}, { 0.112026, -0.993705},
++    { 0.659378, -0.751811}, {-0.615064, -0.788477}, {-0.00328067, 0.999995},
++    { 0.902263, -0.431186}, { 0.201174, -0.979556}, { 0.541589, 0.840644},
++    {-0.996013, 0.0892081}, { 0.987237, 0.159261}, {-0.692353, 0.721559},
++    { 0.940855, -0.338809}, { 0.164224, -0.986423}, { 0.0618662, 0.998084},
++    { 0.784694, 0.619883}, { 0.156281, -0.987713}, {-0.424548, -0.905405},
++    { 0.927622, 0.37352}, {-0.923711, 0.383089}, { 0.708767, -0.705442},
++    {-0.941076, 0.338195}, {-0.268226, 0.963356}, { 0.653964, 0.756526},
++    { 0.983767, -0.179452}, {-0.480029, 0.877253}, {-0.845565, -0.533873},
++    {-0.768586, -0.639746}, { 0.208936, 0.977929}, { 0.512539, -0.858664},
++    { 0.988163, -0.153409}, { 0.780816, 0.624761}, {-0.232748, 0.972537},
++    { 0.988528, -0.151035}, {-0.106602, -0.994302}, {-0.633295, 0.773911},
++    { 0.322068, -0.946717}, { 0.989632, -0.143627}, { 0.973492, -0.228721},
++    { 0.998266, 0.0588631}, {-0.145619, 0.989341}
++};
++
++#endif /* AVCODEC_AC4DEC_DATA_H */
+diff --git a/libavcodec/kbdwin.h b/libavcodec/kbdwin.h
+index 4185c4206f..9c43a6eedf 100644
+--- a/libavcodec/kbdwin.h
++++ b/libavcodec/kbdwin.h
+@@ -32,7 +32,7 @@
+  * @param   alpha   determines window shape
+  * @param   n       size of half window, max FF_KBD_WINDOW_MAX
+  */
+-void ff_kbd_window_init(float *window, float alpha, int n);
+-void ff_kbd_window_init_fixed(int32_t *window, float alpha, int n);
++av_cold void ff_kbd_window_init(float *window, float alpha, int n);
++av_cold void ff_kbd_window_init_fixed(int32_t *window, float alpha, int n);
+ 
+ #endif /* AVCODEC_KBDWIN_H */
+diff --git a/libavformat/mpegts.c b/libavformat/mpegts.c
+index 427bb88a3e..9156e34234 100644
+--- a/libavformat/mpegts.c
++++ b/libavformat/mpegts.c
+@@ -879,6 +879,7 @@ static const StreamType HLS_SAMPLE_ENC_types[] = {
+ static const StreamType REGD_types[] = {
+     { MKTAG('d', 'r', 'a', 'c'), AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_DIRAC },
+     { MKTAG('A', 'C', '-', '3'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC3   },
++    { MKTAG('A', 'C', '-', '4'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4 },
+     { MKTAG('A', 'C', '-', '4'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC4   },
+     { MKTAG('B', 'S', 'S', 'D'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_S302M },
+     { MKTAG('D', 'T', 'S', '1'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_DTS   },
+@@ -2247,6 +2248,11 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type
+         ext_desc_tag = get8(pp, desc_end);
+         if (ext_desc_tag < 0)
+             return AVERROR_INVALIDDATA;
++        if (st->codecpar->codec_id == AV_CODEC_ID_BIN_DATA &&
++            ext_desc_tag == 0x15) {
++            st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
++            st->codecpar->codec_id = AV_CODEC_ID_AC4;
++        }
+         if (st->codecpar->codec_id == AV_CODEC_ID_OPUS &&
+             ext_desc_tag == 0x80) { /* User defined (provisional Opus) */
+             if (!st->codecpar->extradata) {


### PR DESCRIPTION
## Description
Adds Dolby AC-4 audio support natively to the system FFmpeg build by extracting the AC-4 decoder and parser logic from librempeg.

### Changes Included:
- **Clean Import**: Imports `ac4dec.c`, `ac4dec_data.h`, and `ac4_parser.c` directly into the FFmpeg tree via a standard, static `.patch` file.
- **DSP Fix**: Adds an internal fallback for `vector_fmul_reverse` to resolve upstream DSP linker errors.
- **Stability Fix**: Bumps `FF_KBD_WINDOW_MAX` to `2048` in `kbdwin.h`. Without this, the larger transform sizes required by AC-4 cause MDCT context overflows and random Kodi segfaults during playback.
- **Live TV / PVR Fix**: Adds ATSC 3.0 descriptor tags (`0x15`) to `mpegts.c` and `mpegts.h`. This ensures AC-4 audio is correctly identified in MPEG-TS streams by external PVR clients that compile against FFmpeg headers.

### License & Attribution
Original AC-4 decoder code by Paul B Mahol, licensed under GPLv3.
Imported from librempeg commit: `b6621dbe73524e6ab86a75de6d27944ec2378618`.
