### PR TITLE
libcec: fallback to Power On Function if Image View On is unsupported

### DIFF
--- a/packages/devel/libcec/patches/libcec-003-fallback-power-on-function.patch
+++ b/packages/devel/libcec/patches/libcec-003-fallback-power-on-function.patch
@@ -1,0 +1,21 @@
+diff --git a/src/libcec/implementations/CECCommandHandler.cpp b/src/libcec/implementations/CECCommandHandler.cpp
+index 2d92622..4ad2dc7 100644
+--- a/src/libcec/implementations/CECCommandHandler.cpp
++++ b/src/libcec/implementations/CECCommandHandler.cpp
+@@ -907,7 +907,16 @@ bool CCECCommandHandler::TransmitSetStreamPath(const cec_logical_address iIniti
+ bool CCECCommandHandler::PowerOn(const cec_logical_address iInitiator, const cec_logical_address iDestination)
+ {
+   if (iDestination == CECDEVICE_TV)
++  {
++    CCECBusDevice* tv = m_processor->GetDevice(iDestination);
++    if (tv && tv->IsUnsupportedFeature(CEC_OPCODE_IMAGE_VIEW_ON))
++    {
++      return TransmitKeypress(iInitiator, iDestination, CEC_USER_CONTROL_CODE_POWER_ON_FUNCTION) &&
++        TransmitKeyRelease(iInitiator, iDestination);
++    }
++
+     return TransmitImageViewOn(iInitiator, iDestination);
++  }
+ 
+   return TransmitKeypress(iInitiator, iDestination, CEC_USER_CONTROL_CODE_POWER) &&
+     TransmitKeyRelease(iInitiator, iDestination);


### PR DESCRIPTION
## Description
This PR introduces a fallback mechanism for waking the TV if it reports that `Image View On` is unsupported.

### Problem
Certain TVs (e.g., some Hisense models) respond to the initial `Image View On` (`40:04`) command by waking up successfully, but then inexplicably send a `Feature Abort` for opcode `04` a few seconds later. 

Because libCEC correctly caches this abort, the next time Kodi attempts to wake the display, libCEC considers `Image View On` to be unsupported. It skips sending `40:04` entirely and only sends `Active Source`. Because the `Image View On` command is missing, the TV (and subsequently the AVR) remains asleep.

### Solution
Instead of disabling the unsupported-opcode cache globally or trying to build an inconsistent vendor ID blocklist, this patch introduces a graceful fallback.

If `CCECCommandHandler::PowerOn` is targeting the TV and `Image View On` is flagged as unsupported, libCEC will now transmit `User Control Pressed: Power On Function` (`40:44:6d`) followed by a Key Release. Testing confirms this discrete power-on command reliably wakes the TV and AVR without relying on `Image View On`, restoring normal wake functionality for subsequent cycles.

## How has this been tested?
To be tested by Discord user rama1313 on Ugoos AM6B+ with Hisense TV:
- First clean wake works (TV receives `Image View On` and subsequently Feature Aborts).
- Subsequent wakes now successfully turn on the TV via the `Power On Function` fallback, rather than failing silently.

Personally, I have not noticed any regressions with this on my non Hisense TV and it seems like a reasonable fix.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the **Code Guidelines** of this project 
- [x] All new and existing tests passed